### PR TITLE
Potential fix for code scanning alert no. 708: Potential use after free

### DIFF
--- a/deps/openssl/openssl/ssl/statem/extensions_clnt.c
+++ b/deps/openssl/openssl/ssl/statem/extensions_clnt.c
@@ -1649,6 +1649,7 @@ int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     }
 
     OPENSSL_free(s->s3.alpn_selected);
+    s->s3.alpn_selected = NULL;  // Set to NULL after freeing
     s->s3.alpn_selected = OPENSSL_malloc(len);
     if (s->s3.alpn_selected == NULL) {
         s->s3.alpn_selected_len = 0;
@@ -1663,6 +1664,7 @@ int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 
     if (s->session->ext.alpn_selected == NULL
             || s->session->ext.alpn_selected_len != len
+            || s->s3.alpn_selected == NULL  // Guard condition to prevent use-after-free
             || memcmp(s->session->ext.alpn_selected, s->s3.alpn_selected, len)
                != 0) {
         /* ALPN not consistent with the old session so cannot use early_data */


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/708](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/708)

To fix the issue, we need to ensure that `s->s3.alpn_selected` is not accessed after it has been freed. This can be achieved by either:
1. Reallocating and reinitializing `s->s3.alpn_selected` immediately after it is freed, or
2. Setting `s->s3.alpn_selected` to `NULL` after freeing it and adding a check before accessing it to ensure it is not `NULL`.

The best approach here is to set `s->s3.alpn_selected` to `NULL` after freeing it on line 1651 and adding a guard condition before the `memcmp` call on line 1666 to ensure it is not accessed if it is `NULL`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
