### PR TITLE
Potential fix for code scanning alert no. 707: Potential use after free

### DIFF
--- a/deps/openssl/openssl/ssl/ssl_sess.c
+++ b/deps/openssl/openssl/ssl/ssl_sess.c
@@ -1164,10 +1164,18 @@ int SSL_set_session_ticket_ext(SSL *s, void *ext_data, int ext_len)
         }
 
         if (ext_data != NULL) {
+            if (s->ext.session_ticket == NULL) {
+                ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+                return 0;
+            }
             s->ext.session_ticket->length = ext_len;
             s->ext.session_ticket->data = s->ext.session_ticket + 1;
             memcpy(s->ext.session_ticket->data, ext_data, ext_len);
         } else {
+            if (s->ext.session_ticket == NULL) {
+                ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+                return 0;
+            }
             s->ext.session_ticket->length = 0;
             s->ext.session_ticket->data = NULL;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/707](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/707)

To fix the issue, we need to ensure that `s->ext.session_ticket` is not dereferenced unless it is confirmed to be non-NULL. This can be achieved by adding a check before the dereference on line 1168. If `s->ext.session_ticket` is `NULL`, the function should return an error code to prevent further execution. This fix ensures that the code does not attempt to access memory that has not been successfully allocated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
