### PR TITLE
Potential fix for code scanning alert no. 702: Potential use after free

### DIFF
--- a/deps/icu-small/source/common/ucharstriebuilder.cpp
+++ b/deps/icu-small/source/common/ucharstriebuilder.cpp
@@ -120,8 +120,13 @@ UCharsTrieBuilder::add(const UnicodeString &s, int32_t value, UErrorCode &errorC
             uprv_memcpy(newElements, elements, (size_t)elementsLength*sizeof(UCharsTrieElement));
         }
         delete[] elements;
+        elements = nullptr;
         elements=newElements;
         elementsCapacity=newCapacity;
+    }
+    if (elements == nullptr) {
+        errorCode = U_MEMORY_ALLOCATION_ERROR;
+        return *this;
     }
     elements[elementsLength++].setTo(s, value, strings, errorCode);
     if(U_SUCCESS(errorCode) && strings.isBogus()) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/702](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/702)

To fix the issue, we need to ensure that `elements` is never accessed after being freed. This can be achieved by resetting the `elements` pointer to `nullptr` immediately after it is deleted. This way, any subsequent access to `elements` will result in a null pointer dereference, which is easier to debug and safer than accessing freed memory. Additionally, we should add a check to ensure that `elements` is not accessed if it is `nullptr`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
