### PR TITLE
Potential fix for code scanning alert no. 601: Unsigned difference expression compared to zero

### DIFF
--- a/deps/ada/ada.h
+++ b/deps/ada/ada.h
@@ -6733,7 +6733,7 @@ inline bool url_aggregator::has_non_empty_username() const noexcept {
 
 inline bool url_aggregator::has_non_empty_password() const noexcept {
   ada_log("url_aggregator::has_non_empty_password");
-  return components.host_start - components.username_end > 0;
+  return components.host_start > components.username_end;
 }
 
 inline bool url_aggregator::has_password() const noexcept {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/601](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/601)

To fix the issue, we need to ensure that the comparison reflects the intended logic without relying on unsigned subtraction. The best approach is to replace the subtraction and comparison with a direct relational comparison between `components.host_start` and `components.username_end`. Specifically:
- Replace `components.host_start - components.username_end > 0` with `components.host_start > components.username_end`.
- This change eliminates the risk of underflow and makes the code more readable and correct.

The fix will be applied to line 6736 in the file `deps/ada/ada.h`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
