### PR TITLE
Potential fix for code scanning alert no. 718: Disabling certificate validation

### DIFF
--- a/test/sequential/test-http2-timeout-large-write.js
+++ b/test/sequential/test-http2-timeout-large-write.js
@@ -51,7 +51,7 @@ server.on('timeout', () => {
 
 server.listen(0, common.mustCall(() => {
   const client = http2.connect(`https://localhost:${server.address().port}`,
-                               { rejectUnauthorized: false });
+                               { ca: fixtures.readKey('agent1-cert.pem') });
 
   const req = client.request({ ':path': '/' });
   req.end();


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/718](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/718)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a secure alternative. Specifically, we will configure the client to trust the self-signed certificate used by the server. This can be achieved by providing the server's certificate as a trusted CA in the client's `ca` option. This approach maintains certificate validation while allowing the test to proceed with the self-signed certificate.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
