### PR TITLE
Potential fix for code scanning alert no. 714: Disabling certificate validation

### DIFF
--- a/test/parallel/test-http2-large-write-close.js
+++ b/test/parallel/test-http2-large-write-close.js
@@ -27,7 +27,7 @@ server.on('stream', common.mustCall((stream) => {
 
 server.listen(0, common.mustCall(() => {
   const client = http2.connect(`https://localhost:${server.address().port}`,
-                               { rejectUnauthorized: false });
+                               { ca: fixtures.readKey('agent1-cert.pem') });
 
   const req = client.request({ ':path': '/' });
   req.end();


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/714](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/714)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a secure alternative. Specifically, we will configure the client to trust the self-signed certificate used by the server. This can be achieved by providing the `ca` (Certificate Authority) option in the client configuration, pointing to the server's certificate. This approach maintains security while allowing the test to run successfully.

Steps:
1. Read the server's certificate file using the `fixtures.readKey` method.
2. Pass the certificate as the `ca` option in the client configuration instead of using `rejectUnauthorized: false`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
