### PR TITLE
Potential fix for code scanning alert no. 717: Disabling certificate validation

### DIFF
--- a/test/sequential/test-http2-timeout-large-write-file.js
+++ b/test/sequential/test-http2-timeout-large-write-file.js
@@ -53,7 +53,7 @@ server.on('timeout', () => {
 
 server.listen(0, common.mustCall(() => {
   const client = http2.connect(`https://localhost:${server.address().port}`,
-                               { rejectUnauthorized: false });
+                               { ca: fixtures.readKey('agent1-cert.pem') });
 
   const req = client.request({ ':path': '/' });
   req.end();


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/717](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/717)

To fix the issue, we should avoid disabling certificate validation by removing the `rejectUnauthorized: false` option. Instead, we can use a self-signed certificate for the server and configure the client to trust this certificate. This approach maintains the security of the TLS connection while allowing the test to run in a controlled environment.

Steps to fix:
1. Generate a self-signed certificate for the server if not already available.
2. Use the self-signed certificate in the server configuration (`key` and `cert` options).
3. Configure the client to trust the self-signed certificate by specifying the `ca` (Certificate Authority) option with the self-signed certificate.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
