### PR TITLE
Potential fix for code scanning alert no. 715: Disabling certificate validation

### DIFF
--- a/test/parallel/test-http2-socket-close.js
+++ b/test/parallel/test-http2-socket-close.js
@@ -39,7 +39,7 @@ h2Server.on('session', (session) => {
 
 netServer.listen(0, common.mustCall(() => {
   const proxyClient = h2.connect(`https://localhost:${netServer.address().port}`, {
-    rejectUnauthorized: false
+    ca: fixtures.readKey('agent1-cert.pem') // Trust the self-signed certificate
   });
 
   proxyClient.on('error', () => {});


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/715](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/715)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure approach. Instead of disabling certificate validation, we can use a self-signed certificate and explicitly trust it in the test environment. This ensures that the connection remains secure while allowing the test to proceed without errors.

Steps to fix:
1. Generate a self-signed certificate if not already available.
2. Use the `ca` option in the `h2.connect` method to specify the trusted certificate authority (CA) for the self-signed certificate.
3. Remove the `rejectUnauthorized: false` option.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
