### PR TITLE
Potential fix for code scanning alert no. 716: Disabling certificate validation

### DIFF
--- a/test/parallel/test-http2-socket-proxy-handler-for-has.js
+++ b/test/parallel/test-http2-socket-proxy-handler-for-has.js
@@ -23,8 +23,7 @@ const server = http2.createSecureServer(serverOptions, common.mustCall(
 server.listen(common.mustCall(() => {
   const port = server.address().port;
   const client = http2.connect('https://localhost:' + port, {
-    ca: fixtures.readKey('agent1-cert.pem'),
-    rejectUnauthorized: false
+    ca: fixtures.readKey('agent1-cert.pem')
   });
   const req = client.request({});
   req.on('response', common.mustCall((headers, flags) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/716](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/716)

To fix the issue, we will remove the `rejectUnauthorized: false` option and ensure that the test uses proper certificate validation. Since the test already specifies a `ca` option with a trusted certificate (`agent1-cert.pem`), the `rejectUnauthorized` option can be safely omitted. This ensures that the connection remains secure while still allowing the test to function as intended.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
