### PR TITLE
Potential fix for code scanning alert no. 713: Disabling certificate validation

### DIFF
--- a/test/parallel/test-http2-large-write-destroy.js
+++ b/test/parallel/test-http2-large-write-destroy.js
@@ -28,7 +28,7 @@ server.on('stream', common.mustCall((stream) => {
 
 server.listen(0, common.mustCall(() => {
   const client = http2.connect(`https://localhost:${server.address().port}`,
-                               { rejectUnauthorized: false });
+                               { ca: fixtures.readKey('agent1-cert.pem') });
 
   const req = client.request({ ':path': '/' });
   req.end();


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/713](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/713)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure configuration. Specifically, we will use a self-signed certificate for the server and configure the client to trust this certificate. This approach maintains the security of the connection while allowing the test to proceed without disabling certificate validation.

Steps to implement the fix:
1. Generate a self-signed certificate if not already available.
2. Use the self-signed certificate for the server (`key` and `cert` options).
3. Configure the client to trust the self-signed certificate by specifying the `ca` (Certificate Authority) option.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
