### PR TITLE
Potential fix for code scanning alert no. 712: Disabling certificate validation

### DIFF
--- a/test/parallel/test-http2-client-connection-tunnelling.js
+++ b/test/parallel/test-http2-client-connection-tunnelling.js
@@ -40,7 +40,7 @@ h2Server.on('connect', (req, res) => {
 
 netServer.listen(0, common.mustCall(() => {
   const proxyClient = h2.connect(`https://localhost:${netServer.address().port}`, {
-    rejectUnauthorized: false
+    ca: fixtures.readKey('agent1-cert.pem') // Use self-signed certificate
   });
 
   const proxyReq = proxyClient.request({
@@ -55,7 +55,7 @@ netServer.listen(0, common.mustCall(() => {
     const tlsSocket = tls.connect({
       socket: proxyReq,
       ALPNProtocols: ['h2'],
-      rejectUnauthorized: false
+      ca: fixtures.readKey('agent1-cert.pem') // Use self-signed certificate
     });
 
     proxyReq.on('close', common.mustCall(() => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/712](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/712)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure alternative. Specifically, we will use a self-signed certificate for the test server and configure the client to trust this certificate. This approach maintains the security of the TLS connection while allowing the test to proceed without disabling certificate validation.

Steps:
1. Generate a self-signed certificate if not already available.
2. Add the self-signed certificate to the `ca` option in the client configuration.
3. Remove the `rejectUnauthorized: false` option.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
