### PR TITLE
Potential fix for code scanning alert no. 711: Disabling certificate validation

### DIFF
--- a/test/parallel/test-http2-cancel-while-client-reading.js
+++ b/test/parallel/test-http2-cancel-while-client-reading.js
@@ -25,7 +25,7 @@ server.on('stream', common.mustCall(function(stream) {
 
 server.listen(0, function() {
   const client = http2.connect(`https://localhost:${server.address().port}`,
-                               { rejectUnauthorized: false }
+                               { ca: cert }
   );
   client_stream = client.request({ ':method': 'POST' });
   client_stream.on('close', common.mustCall(() => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/711](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/711)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a secure alternative. Specifically, we will use a self-signed certificate for the server and configure the client to trust this certificate. This ensures that certificate validation is performed, even in the test environment, while still allowing the test to run successfully.

Steps:
1. Use the existing `key` and `cert` variables to create a self-signed certificate for the server.
2. Pass the server's certificate as a trusted CA to the client using the `ca` option in the `http2.connect` method.
3. Remove the `rejectUnauthorized: false` option.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
