### PR TITLE
Potential fix for code scanning alert no. 585: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -38,7 +38,7 @@ function runTest(clientsOptions, serverOptions, cb) {
     const opt = options.shift();
     opt.port = server.address().port;
     opt.host = serverIP;
-    opt.rejectUnauthorized = false;
+    opt.ca = loadPEM('agent2-cert'); // Use the server's certificate for validation
 
     results[clientIndex] = {};
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/585](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/585)

To fix the issue, we will remove the line that sets `opt.rejectUnauthorized = false` and ensure that certificate validation is enabled. If the test environment requires a specific certificate, we can configure the client to trust a self-signed certificate or a custom CA certificate. This approach maintains security while allowing the test to function as intended.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
