### PR TITLE
Potential fix for code scanning alert no. 583: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-client-get-url.js
+++ b/test/parallel/test-https-client-get-url.js
@@ -25,8 +25,8 @@ const fixtures = require('../common/fixtures');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-// Disable strict server certificate validation by the client
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+// Use a custom HTTPS agent to disable strict server certificate validation for specific requests
+const insecureAgent = new https.Agent({ rejectUnauthorized: false });
 
 const assert = require('assert');
 const https = require('https');
@@ -47,9 +47,9 @@ const server = https.createServer(options, common.mustCall((req, res) => {
 
 server.listen(0, common.mustCall(() => {
   const u = `https://${common.localhostIPv4}:${server.address().port}/foo?bar`;
-  https.get(u, common.mustCall(() => {
-    https.get(url.parse(u), common.mustCall(() => {
-      https.get(new URL(u), common.mustCall(() => {
+  https.get(u, { agent: insecureAgent }, common.mustCall(() => {
+    https.get(url.parse(u), { agent: insecureAgent }, common.mustCall(() => {
+      https.get(new URL(u), { agent: insecureAgent }, common.mustCall(() => {
         server.close();
       }));
     }));


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/583](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/583)

To fix the issue, we should avoid globally disabling certificate validation by setting `process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'`. Instead, we can use a custom HTTPS agent with `rejectUnauthorized: false` for the specific requests that require it. This ensures that certificate validation is only disabled for the intended test cases and does not affect the entire process.

The changes involve:
1. Removing the global `process.env.NODE_TLS_REJECT_UNAUTHORIZED` setting.
2. Creating a custom `https.Agent` with `rejectUnauthorized: false` and passing it explicitly to the HTTPS requests in the test.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
