### PR TITLE
Potential fix for code scanning alert no. 581: Disabling certificate validation

### DIFF
--- a/test/parallel/test-http-url.parse-https.request.js
+++ b/test/parallel/test-http-url.parse-https.request.js
@@ -50,7 +50,6 @@ const server = https.createServer(httpsOptions, function(request, response) {
 
 server.listen(0, function() {
   const testURL = url.parse(`https://localhost:${this.address().port}`);
-  testURL.rejectUnauthorized = false;
 
   // make the request
   const clientRequest = https.request(testURL);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/581](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/581)

To fix the issue, the `rejectUnauthorized` option should not be set to `false`. Instead, the default behavior (which enforces certificate validation) should be preserved. If the test requires bypassing certificate validation, an alternative approach, such as using a self-signed certificate and adding it to the trusted CA list, should be implemented. This ensures that the test remains secure while achieving the desired functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
