### PR TITLE
Potential fix for code scanning alert no. 580: Disabling certificate validation

### DIFF
--- a/benchmark/tls/secure-pair.js
+++ b/benchmark/tls/secure-pair.js
@@ -38,7 +38,7 @@ function main({ dur, size, securing }) {
         key: options.key,
         cert: options.cert,
         isServer: false,
-        rejectUnauthorized: false,
+        rejectUnauthorized: true, // Ensure certificate validation is enabled
         maxVersion: options.maxVersion,
       };
       const network = securing === 'clear' ? net : tls;


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/580](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/580)

To fix the issue, the `rejectUnauthorized` option in the `clientOptions` object should be set to `true` to enable certificate validation. This ensures that the client verifies the server's certificate during the TLS handshake, maintaining the security of the connection. If the intention is to use this code in a testing environment, a comment can be added to clarify the purpose and ensure it is not misused in production.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
