### PR TITLE
Potential fix for code scanning alert no. 579: Disabling certificate validation

### DIFF
--- a/benchmark/tls/tls-connect.js
+++ b/benchmark/tls/tls-connect.js
@@ -43,7 +43,7 @@ function onConnection(conn) {
 function makeConnection() {
   const options = {
     port: common.PORT,
-    rejectUnauthorized: false,
+    rejectUnauthorized: true,
   };
   const conn = tls.connect(options, () => {
     clientConn++;


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/579](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/579)

To fix the issue, we should ensure that certificate validation is enabled by setting `rejectUnauthorized` to its default value (`true`) or removing the option entirely. If the intent is to use this code in a testing environment where certificate validation is not feasible, we should explicitly document this with comments and consider using a self-signed certificate with a trusted CA to maintain some level of security.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
