### PR TITLE
Potential fix for code scanning alert no. 577: Disabling certificate validation

### DIFF
--- a/benchmark/tls/throughput-s2c.js
+++ b/benchmark/tls/throughput-s2c.js
@@ -46,7 +46,7 @@ function main({ dur, type, sendchunklen, recvbuflen, recvbufgenfn }) {
 
   let socketOpts;
   if (recvbuf === undefined) {
-    socketOpts = { port: common.PORT, rejectUnauthorized: false };
+    socketOpts = { port: common.PORT, ca: fixtures.readKey('rsa_ca.crt') };
   } else {
     let buffer = recvbuf;
     if (recvbufgenfn === 'true') {
@@ -63,7 +63,7 @@ function main({ dur, type, sendchunklen, recvbuflen, recvbufgenfn }) {
     }
     socketOpts = {
       port: common.PORT,
-      rejectUnauthorized: false,
+      ca: fixtures.readKey('rsa_ca.crt'),
       onread: {
         buffer,
         callback: function(nread, buf) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/577](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/577)

To fix the issue, we will remove the `rejectUnauthorized: false` option and ensure that certificate validation is enabled. If the intention is to use self-signed certificates for testing, we can explicitly provide the `ca` (Certificate Authority) option with the trusted certificate. This approach maintains security while allowing the test to proceed with a known certificate.

Changes will be made to the `socketOpts` object on lines 49 and 66 to remove `rejectUnauthorized: false` and replace it with a `ca` option that points to the trusted certificate.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
