### PR TITLE
Potential fix for code scanning alert no. 576: Disabling certificate validation

### DIFF
--- a/benchmark/tls/throughput-c2s.js
+++ b/benchmark/tls/throughput-c2s.js
@@ -40,7 +40,10 @@ function main({ dur, type, size }) {
   const server = tls.createServer(options, onConnection);
   let conn;
   server.listen(common.PORT, () => {
-    const opt = { port: common.PORT, rejectUnauthorized: false };
+    const opt = { 
+      port: common.PORT, 
+      ca: fixtures.readKey('rsa_ca.crt') // Use the CA certificate for validation
+    };
     conn = tls.connect(opt, () => {
       setTimeout(done, dur * 1000);
       bench.start();


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/576](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/576)

To fix the issue, we will remove the `rejectUnauthorized: false` option and ensure that the connection validates certificates. If the script is intended for testing, we can use a self-signed certificate or a test CA to maintain security while allowing the connection to succeed. This involves ensuring that the `ca` option in the client configuration matches the CA used to sign the server's certificate.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
