### PR TITLE
Potential fix for code scanning alert no. 575: Disabling certificate validation

### DIFF
--- a/test/sequential/test-https-server-keep-alive-timeout.js
+++ b/test/sequential/test-https-server-keep-alive-timeout.js
@@ -45,7 +45,7 @@ test(function serverKeepAliveTimeoutWithPipeline(cb) {
     const options = {
       port: server.address().port,
       allowHalfOpen: true,
-      rejectUnauthorized: false
+      ca: fixtures.readKey('agent1-cert.pem')
     };
     const c = tls.connect(options, () => {
       c.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');
@@ -68,7 +68,7 @@ test(function serverNoEndKeepAliveTimeoutWithPipeline(cb) {
     const options = {
       port: server.address().port,
       allowHalfOpen: true,
-      rejectUnauthorized: false
+      ca: fixtures.readKey('agent1-cert.pem')
     };
     const c = tls.connect(options, () => {
       c.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/575](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/575)

To fix the issue, we should avoid setting `rejectUnauthorized: false`. Instead, we can use a self-signed certificate or a test CA to ensure that the connection remains secure during testing. This involves:
1. Removing the `rejectUnauthorized: false` option from the `tls.connect` configuration.
2. Optionally, adding a `ca` property to the options object to specify the trusted CA or certificate for the test server.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
