### PR TITLE
Potential fix for code scanning alert no. 573: Disabling certificate validation

### DIFF
--- a/test/sequential/test-https-connect-localport.js
+++ b/test/sequential/test-https-connect-localport.js
@@ -25,7 +25,7 @@ const assert = require('assert');
       port,
       family: 4,
       localPort: common.PORT,
-      rejectUnauthorized: false,
+      ca: fixtures.readKey('agent1-cert.pem'),
     }, common.mustCall(() => {
       assert.strictEqual(req.socket.localPort, common.PORT);
       assert.strictEqual(req.socket.remotePort, port);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/573](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/573)

To fix the issue, we will remove the `rejectUnauthorized: false` option and ensure that the test uses a valid certificate. If the test requires a self-signed certificate, we can configure the HTTPS client to trust the self-signed certificate by specifying the `ca` (certificate authority) option. This approach maintains certificate validation while allowing the test to function as intended.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
