### PR TITLE
Potential fix for code scanning alert no. 572: Disabling certificate validation

### DIFF
--- a/test/pummel/test-tls-throttle.js
+++ b/test/pummel/test-tls-throttle.js
@@ -49,7 +49,7 @@ let recvCount = 0;
 server.listen(0, function() {
   const client = tls.connect({
     port: server.address().port,
-    rejectUnauthorized: false,
+    ca: [fixtures.readKey('agent2-cert.pem')],
   });
 
   client.on('data', function(d) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/572](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/572)

To fix the issue, the `rejectUnauthorized` option should be removed or explicitly set to `true`. This ensures that certificate validation is enabled, maintaining the security of the TLS connection. If the test requires a self-signed certificate, the test should configure the client to trust the specific certificate used by the server, rather than disabling validation entirely. This can be achieved by providing the `ca` option with the server's certificate.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
