### PR TITLE
Potential fix for code scanning alert no. 571: Disabling certificate validation

### DIFF
--- a/test/pummel/test-tls-server-large-request.js
+++ b/test/pummel/test-tls-server-large-request.js
@@ -62,7 +62,7 @@ const server = tls.Server(options, common.mustCall(function(socket) {
 server.listen(0, common.mustCall(() => {
   const client1 = tls.connect({
     port: server.address().port,
-    rejectUnauthorized: false,
+    ca: [fixtures.readKey('agent1-cert.pem')],
   }, common.mustCall(function() {
     client1.end(request);
   }));


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/571](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/571)

To fix the issue, we will remove the `rejectUnauthorized: false` option and ensure that the test uses a valid certificate for the TLS connection. This can be achieved by explicitly specifying the `ca` (Certificate Authority) option in the client configuration, pointing to the same certificate used by the server. This approach maintains the integrity of the TLS connection while still allowing the test to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
