### PR TITLE
Potential fix for code scanning alert no. 570: Disabling certificate validation

### DIFF
--- a/test/pummel/test-https-large-response.js
+++ b/test/pummel/test-https-large-response.js
@@ -46,7 +46,7 @@ const server = https.createServer(options, common.mustCall(function(req, res) {
 server.listen(0, common.mustCall(function() {
   https.get({
     port: server.address().port,
-    rejectUnauthorized: false,
+    ca: fixtures.readKey('agent1-cert.pem'),
   }, common.mustCall(function(res) {
     console.log('response!');
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/570](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/570)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure alternative. Specifically, we will configure the HTTPS client to trust the self-signed certificate used by the test server. This can be achieved by providing the `ca` option with the certificate authority (CA) certificate corresponding to the server's self-signed certificate. This ensures that the connection remains secure while allowing the test to proceed with the self-signed certificate.

Steps:
1. Read the CA certificate from the test fixtures.
2. Pass the CA certificate to the `https.get` options using the `ca` property.
3. Remove the `rejectUnauthorized: false` option.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
