### PR TITLE
Potential fix for code scanning alert no. 568: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-wrap-timeout.js
+++ b/test/parallel/test-tls-wrap-timeout.js
@@ -43,7 +43,8 @@ server.listen(0, () => {
 
     const tsocket = tls.connect({
       socket: socket,
-      rejectUnauthorized: false
+      rejectUnauthorized: true,
+      ca: fixtures.readKey('agent1-cert.pem') // Use the trusted CA certificate
     });
     tsocket.resume();
   });


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/568](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/568)

To fix the issue, we will replace `rejectUnauthorized: false` with `rejectUnauthorized: true` to ensure that certificate validation is enabled. If the test requires a specific certificate to be trusted, we can use the `ca` option to provide the certificate authority (CA) certificate for validation. This approach maintains the integrity of the test while adhering to best security practices.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
