### PR TITLE
Potential fix for code scanning alert no. 569: Disabling certificate validation

### DIFF
--- a/test/pummel/test-https-no-reader.js
+++ b/test/pummel/test-https-no-reader.js
@@ -47,7 +47,7 @@ server.listen(0, function() {
   const req = https.request({
     method: 'POST',
     port: server.address().port,
-    rejectUnauthorized: false,
+    ca: fixtures.readKey('rsa_cert.crt'), // Use the test certificate as a trusted CA
   }, function(res) {
     res.read(0);
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/569](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/569)

To fix the issue, we will remove the `rejectUnauthorized: false` option from the HTTPS request configuration. This will restore the default behavior of validating certificates. If the test requires a specific certificate to be trusted, we can configure the `ca` option to include the certificate authority (CA) of the test certificate. This approach maintains security while allowing the test to function as intended.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
