### PR TITLE
Potential fix for code scanning alert no. 563: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-timeout-server-2.js
+++ b/test/parallel/test-tls-timeout-server-2.js
@@ -45,6 +45,6 @@ server.listen(0, common.mustCall(function() {
   tls.connect({
     host: '127.0.0.1',
     port: this.address().port,
-    rejectUnauthorized: false
+    ca: [fixtures.readKey('agent1-cert.pem')]
   });
 }));


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/563](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/563)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a secure alternative. Specifically, we will use a self-signed certificate for the server and configure the client to trust this certificate. This approach maintains certificate validation while allowing the test to proceed without requiring a certificate from a public certificate authority.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
