### PR TITLE
Potential fix for code scanning alert no. 561: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-streamwrap-buffersize.js
+++ b/test/parallel/test-tls-streamwrap-buffersize.js
@@ -50,7 +50,7 @@ const net = require('net');
     createDuplex(port).then((socket) => {
       const client = tls.connect({
         socket,
-        rejectUnauthorized: false,
+        ca: [fixtures.readKey('agent2-cert.pem')],
       }, common.mustCall(() => {
         assert.strictEqual(client.bufferSize, 0);
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/561](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/561)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure alternative. Specifically, we will configure the TLS connection to use a trusted CA for certificate validation. This ensures that the connection remains secure while still allowing the test to run in a controlled environment. The CA file can be loaded from the `fixtures` directory, which already contains test certificates.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
