### PR TITLE
Potential fix for code scanning alert no. 560: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-starttls-server.js
+++ b/test/parallel/test-tls-starttls-server.js
@@ -38,6 +38,8 @@ const server = net.createServer(common.mustCall((s) => {
   const opts = {
     servername: 'test.test',
     port: server.address().port,
+    // Note: `rejectUnauthorized: false` is used here for testing purposes only.
+    // Do not use this setting in production as it disables certificate validation.
     rejectUnauthorized: false,
     requestOCSP: true
   };


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/560](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/560)

To address the issue, we will explicitly document that the `rejectUnauthorized: false` option is used for testing purposes only. Additionally, we will add a comment to clarify that this setting should not be used in production. This ensures that the intent is clear and reduces the risk of this insecure configuration being copied into production code. No functional changes will be made to the test itself, as the setting is necessary for the test to function as intended.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
