### PR TITLE
Potential fix for code scanning alert no. 559: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-socket-destroy.js
+++ b/test/parallel/test-tls-socket-destroy.js
@@ -27,7 +27,7 @@ const server = net.createServer(common.mustCall((conn) => {
 server.listen(0, function() {
   const options = {
     port: this.address().port,
-    rejectUnauthorized: false,
+    ca: fixtures.readKey('agent1-cert.pem'), // Use trusted self-signed certificate
   };
   tls.connect(options, function() {
     this.write('*'.repeat(1 << 20));  // Write more data than fits in a frame.


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/559](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/559)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a secure alternative. Specifically, we will configure the test to use a trusted self-signed certificate for the TLS connection. This ensures that certificate validation is enabled while still allowing the test to function as intended. The fix involves:

1. Generating a self-signed certificate and key (if not already available in the `fixtures` directory).
2. Updating the client connection options to include the `ca` (Certificate Authority) option, pointing to the self-signed certificate.
3. Removing the `rejectUnauthorized: false` option.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
