### PR TITLE
Potential fix for code scanning alert no. 558: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-socket-close.js
+++ b/test/parallel/test-tls-socket-close.js
@@ -46,7 +46,7 @@ function connectClient(server) {
   const clientTlsSocket = tls.connect({
     host: 'localhost',
     port: server.address().port,
-    rejectUnauthorized: false
+    ca: cert // Use the server's certificate to establish trust
   });
 
   clientTlsSocket.write('.');


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/558](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/558)

To fix the issue, we should avoid disabling certificate validation by setting `rejectUnauthorized` to `true` or omitting it entirely (as `true` is the default). Since this is a test file, we can provide a trusted certificate for the test server to ensure the connection remains secure while still allowing the test to function as intended. This involves ensuring that the client trusts the server's certificate by specifying the `ca` (Certificate Authority) option in the `tls.connect` configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
