### PR TITLE
Potential fix for code scanning alert no. 557: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-socket-constructor-alpn-options-parsing.js
+++ b/test/parallel/test-tls-socket-constructor-alpn-options-parsing.js
@@ -39,7 +39,6 @@ const server = net.createServer(common.mustCall((s) => {
 server.listen(0, common.mustCall(() => {
   const alpnOpts = {
     port: server.address().port,
-    rejectUnauthorized: false,
     ALPNProtocols: ['h2', 'http/1.1']
   };
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/557](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/557)

To fix the issue, we should remove the `rejectUnauthorized: false` option or set it to `true` to enable certificate validation. If the test requires disabling certificate validation, we should add a comment explaining why it is necessary and ensure that it is only used in a controlled testing environment. Additionally, we can use self-signed certificates for testing purposes to maintain security while avoiding the need to disable validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
