### PR TITLE
Potential fix for code scanning alert no. 547: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -36,7 +36,7 @@ const serverOptions = {
   key: loadPEM('agent2-key'),
   cert: loadPEM('agent2-cert'),
   requestCert: true,
-  rejectUnauthorized: false,
+  rejectUnauthorized: true,
   SNICallback: function(servername, callback) {
     const context = SNIContexts[servername];
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/547](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/547)

To fix the issue, the `rejectUnauthorized` option should be set to `true` to enable certificate validation. If the test requires bypassing certificate validation, it should be done in a controlled and documented manner, such as by using a mock or self-signed certificate that is explicitly trusted for the test. This ensures that the test environment remains secure and does not propagate insecure practices.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
