### PR TITLE
Potential fix for code scanning alert no. 545: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-set-encoding.js
+++ b/test/parallel/test-tls-set-encoding.js
@@ -48,7 +48,7 @@ const server = tls.Server(options, common.mustCall(function(socket) {
 server.listen(0, function() {
   const client = tls.connect({
     port: this.address().port,
-    rejectUnauthorized: false
+    ca: fixtures.readKey('agent2-cert.pem')
   });
 
   let buffer = '';


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/545](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/545)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure alternative. Specifically, we will use a self-signed certificate for the server and configure the client to trust this certificate. This approach maintains the integrity of the TLS connection while allowing the test to proceed in a controlled environment.

The changes involve:
1. Adding the `ca` (Certificate Authority) option to the client configuration, pointing to the self-signed certificate used by the server.
2. Removing the `rejectUnauthorized: false` option.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
