### PR TITLE
Potential fix for code scanning alert no. 544: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-server-parent-constructor-options.js
+++ b/test/parallel/test-tls-server-parent-constructor-options.js
@@ -28,7 +28,7 @@ const options = {
   server.listen(0, common.mustCall(() => {
     const socket = tls.connect({
       port: server.address().port,
-      rejectUnauthorized: false
+      // Certificate validation is enabled by default.
     }, common.mustCall(() => {
       socket.end();
     }));
@@ -56,7 +56,7 @@ const options = {
   server.listen(0, common.mustCall(() => {
     const socket = tls.connect({
       port: server.address().port,
-      rejectUnauthorized: false
+      // Certificate validation is enabled by default.
     }, common.mustCall(() => {
       socket.end();
     }));


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/544](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/544)

To address the issue, we will remove the `rejectUnauthorized: false` option from the `tls.connect` calls. This ensures that certificate validation is enabled, which is the default behavior. If the test requires disabling certificate validation, we will add a comment explicitly stating the reason and ensure it is limited to the test environment. Additionally, we will explore whether the test can be rewritten to avoid disabling certificate validation altogether.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
