### PR TITLE
Potential fix for code scanning alert no. 543: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-server-setkeycert.js
+++ b/test/parallel/test-tls-server-setkeycert.js
@@ -40,6 +40,8 @@ const altKeyCertVals = [
 
     tls.connect({
       port: this.address().port,
+      // Disabling certificate validation for testing purposes only.
+      // This should never be used in production environments.
       rejectUnauthorized: false,
       ALPNProtocols: ['acme-tls/1'],
     }, common.mustCall(function() {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/543](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/543)

To address the issue, we will explicitly document that `rejectUnauthorized: false` is used for testing purposes and ensure that it is isolated to the test environment. We will add a comment explaining why certificate validation is disabled and confirm that this behavior is limited to the test suite. Additionally, we will consider using an environment variable or a configuration flag to make it clear that this behavior is intentional and restricted to testing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
