### PR TITLE
Potential fix for code scanning alert no. 541: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-server-capture-rejection.js
+++ b/test/parallel/test-tls-server-capture-rejection.js
@@ -27,7 +27,7 @@ server.listen(0, common.mustCall(() => {
   const sock = connect({
     port: server.address().port,
     host: server.address().host,
-    rejectUnauthorized: false
+    ca: cert
   });
 
   sock.on('close', common.mustCall());


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/541](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/541)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure configuration. Specifically, we will use a self-signed certificate for the server and configure the client to trust this certificate. This approach maintains the integrity of the test while ensuring that certificate validation is not disabled.

Steps:
1. Generate a self-signed certificate and private key (if not already available).
2. Use the self-signed certificate and private key for the server.
3. Configure the client to trust the self-signed certificate by specifying the `ca` (Certificate Authority) option.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
