### PR TITLE
Potential fix for code scanning alert no. 540: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-server-connection-server.js
+++ b/test/parallel/test-tls-server-connection-server.js
@@ -18,7 +18,7 @@ const server = tls.createServer(options, function(s) {
 }).listen(0, function() {
   const opts = {
     port: this.address().port,
-    rejectUnauthorized: false
+    ca: fixtures.readKey('agent1-cert.pem') // Use the server's certificate as the trusted CA
   };
 
   server.on('connection', common.mustCall(function(socket) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/540](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/540)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure alternative. Specifically, we will configure the test to use a self-signed certificate or a trusted test certificate. This ensures that certificate validation remains enabled while still allowing the test to function as intended. The `ca` (Certificate Authority) option will be added to the client options, pointing to the same certificate used by the server. This approach maintains security while supporting the test's requirements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
