### PR TITLE
Potential fix for code scanning alert no. 539: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-secure-session.js
+++ b/test/parallel/test-tls-secure-session.js
@@ -25,7 +25,6 @@ const server = tls.createServer(options, common.mustCall((socket) => {
   let session = null;
 
   const client = tls.connect({
-    rejectUnauthorized: false,
     port: server.address().port,
   }, common.mustCall(() => {
     assert(!connected);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/539](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/539)

To fix the issue, we should remove the `rejectUnauthorized: false` option or set it to `true` to ensure certificate validation is enabled. If the test requires bypassing certificate validation, we should use a secure and explicit mechanism, such as providing a trusted certificate authority (CA) or using self-signed certificates with proper validation. This ensures the test remains secure while achieving its intended purpose.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
