### PR TITLE
Potential fix for code scanning alert no. 538: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-secure-context-usage-order.js
+++ b/test/parallel/test-tls-secure-context-usage-order.js
@@ -60,7 +60,7 @@ server.listen(0, () => {
     cert: loadPEM('agent1-cert'),
     ca: [loadPEM('ca1-cert')],
     servername: 'a.example.com',
-    rejectUnauthorized: false,
+    rejectUnauthorized: true,
   };
 
   // 2. Make a connection using servername 'a.example.com'. Since a 'bad'


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/538](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/538)

To fix the issue, we will replace `rejectUnauthorized: false` with `rejectUnauthorized: true` in the test code. This ensures that certificate validation is enabled. If the test requires a specific certificate to be trusted, we can use a self-signed certificate or a mock CA certificate to simulate the desired behavior. This approach maintains the integrity of the test while adhering to best practices for TLS security.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
