### PR TITLE
Potential fix for code scanning alert no. 533: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-passphrase.js
+++ b/test/parallel/test-tls-passphrase.js
@@ -231,7 +231,7 @@ assert.throws(function() {
     port: server.address().port,
     key: passKey,
     cert: cert,
-    rejectUnauthorized: false
+    // rejectUnauthorized: false // Removed for security
   });
 }, errMessageDecrypt);
 
@@ -240,7 +240,7 @@ assert.throws(function() {
     port: server.address().port,
     key: [passKey],
     cert: cert,
-    rejectUnauthorized: false
+    // rejectUnauthorized: false // Removed for security
   });
 }, errMessageDecrypt);
 
@@ -249,7 +249,7 @@ assert.throws(function() {
     port: server.address().port,
     key: [{ pem: passKey }],
     cert: cert,
-    rejectUnauthorized: false
+    // rejectUnauthorized: false // Removed for security
   });
 }, errMessageDecrypt);
 
@@ -260,7 +260,7 @@ assert.throws(function() {
     key: passKey,
     passphrase: 'invalid',
     cert: cert,
-    rejectUnauthorized: false
+    // rejectUnauthorized: false // Removed for security
   });
 }, errMessageDecrypt);
 
@@ -270,7 +270,7 @@ assert.throws(function() {
     key: [passKey],
     passphrase: 'invalid',
     cert: cert,
-    rejectUnauthorized: false
+    // rejectUnauthorized: false // Removed for security
   });
 }, errMessageDecrypt);
 
@@ -280,7 +280,7 @@ assert.throws(function() {
     key: [{ pem: passKey }],
     passphrase: 'invalid',
     cert: cert,
-    rejectUnauthorized: false
+    // rejectUnauthorized: false // Removed for security
   });
 }, errMessageDecrypt);
 
@@ -290,6 +290,6 @@ assert.throws(function() {
     key: [{ pem: passKey, passphrase: 'invalid' }],
     passphrase: 'password', // Valid but unused
     cert: cert,
-    rejectUnauthorized: false
+    // rejectUnauthorized: false // Removed for security
   });
 }, errMessageDecrypt);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/533](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/533)

To address the issue, we will remove the `rejectUnauthorized: false` option from the `tls.connect` calls. If the test requires bypassing certificate validation, we will replace it with a secure alternative, such as using a self-signed certificate and adding it to the trusted CA list. This ensures that the test environment remains secure while still achieving the desired behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
