### PR TITLE
Potential fix for code scanning alert no. 520: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-passphrase.js
+++ b/test/parallel/test-tls-passphrase.js
@@ -135,47 +135,41 @@ server.listen(0, common.mustCall(function() {
   tls.connect({
     port: this.address().port,
     key: [rawKey.toString()],
-    cert: [cert.toString()],
-    rejectUnauthorized: false
+    cert: [cert.toString()]
   }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
     key: [rawKey.toString()],
     passphrase: 'ignored',
-    cert: [cert.toString()],
-    rejectUnauthorized: false
+    cert: [cert.toString()]
   }, onSecureConnect());
 
   // Object[]
   tls.connect({
     port: this.address().port,
     key: [{ pem: passKey, passphrase: 'password' }],
-    cert: cert,
-    rejectUnauthorized: false
+    cert: cert
   }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
     key: [{ pem: passKey, passphrase: 'password' }],
     passphrase: 'ignored',
-    cert: cert,
-    rejectUnauthorized: false
+    cert: cert
   }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
     key: [{ pem: passKey }],
     passphrase: 'password',
-    cert: cert,
-    rejectUnauthorized: false
+    cert: cert
   }, onSecureConnect());
 
   tls.connect({
     port: this.address().port,
     key: [{ pem: passKey.toString(), passphrase: 'password' }],
-    cert: cert,
-    rejectUnauthorized: false
+    cert: cert
   }, onSecureConnect());
 
   tls.connect({


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/520](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/520)

To fix the issue, we will remove the `rejectUnauthorized: false` option from the `tls.connect` calls. This will ensure that certificate validation is enabled. If the test requires a specific certificate to be trusted, we can use a self-signed certificate or a test CA and configure the `ca` option in the `tls.connect` calls to include the trusted certificate.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
