### PR TITLE
Potential fix for code scanning alert no. 517: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-request-timeout.js
+++ b/test/parallel/test-tls-request-timeout.js
@@ -46,6 +46,6 @@ const server = tls.Server(options, common.mustCall(function(socket) {
 server.listen(0, function() {
   tls.connect({
     port: this.address().port,
-    rejectUnauthorized: false
+    ca: [fixtures.readKey('agent1-cert.pem')]
   });
 });


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/517](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/517)

To fix the issue, we will replace `rejectUnauthorized: false` with a configuration that validates certificates while still allowing the test to run in a controlled environment. This can be achieved by using a self-signed certificate and explicitly trusting it in the test. This approach maintains the integrity of the TLS connection while ensuring the test functions as intended.

Steps to fix:
1. Replace `rejectUnauthorized: false` with `ca: [fixtures.readKey('agent1-cert.pem')]` to trust the self-signed certificate used by the server.
2. Ensure the test setup uses the same certificate for both the server and the client.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
