### PR TITLE
Potential fix for code scanning alert no. 516: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-reinitialize-listeners.js
+++ b/test/parallel/test-tls-reinitialize-listeners.js
@@ -25,7 +25,8 @@ const server = tls.createServer({
 server.listen(0, common.mustCall(function() {
   const socket = tls.connect({
     port: this.address().port,
-    rejectUnauthorized: false
+    rejectUnauthorized: true,
+    ca: [fixtures.readKey('agent1-cert.pem')]
   });
 
   socket.on('secureConnect', common.mustCall(function() {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/516](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/516)

To fix the issue, we will replace `rejectUnauthorized: false` with `rejectUnauthorized: true` to enable certificate validation. Additionally, we will ensure that the test uses a valid certificate for the connection. Since the test already uses certificates (`agent1-key.pem` and `agent1-cert.pem`), we will add the `ca` option to the client configuration to trust the server's certificate. This ensures that the test remains functional while adhering to secure practices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
