### PR TITLE
Potential fix for code scanning alert no. 502: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-peer-certificate-multi-keys.js
+++ b/test/parallel/test-tls-peer-certificate-multi-keys.js
@@ -49,7 +49,7 @@ server.once('secureConnection', common.mustCall(function(socket) {
 server.listen(0, common.mustCall(function() {
   const socket = tls.connect({
     port: this.address().port,
-    rejectUnauthorized: false
+    ca: [fixtures.readKey('rsa_cert.crt')]
   }, common.mustCall(function() {
     const peerCert = socket.getPeerCertificate();
     assert.deepStrictEqual(


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/502](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/502)

To address the issue, we will replace `rejectUnauthorized: false` with a more secure approach. Specifically, we will configure the test to use a self-signed certificate and ensure that the client trusts this certificate. This allows the test to proceed without disabling certificate validation while maintaining security.

The changes involve:
1. Generating a self-signed certificate and private key (if not already available in the `fixtures` directory).
2. Adding the `ca` option to the client configuration to trust the self-signed certificate used by the server.
3. Removing the `rejectUnauthorized: false` option.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
