### PR TITLE
Potential fix for code scanning alert no. 500: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-peer-certificate-encoding.js
+++ b/test/parallel/test-tls-peer-certificate-encoding.js
@@ -40,8 +40,7 @@ const server = tls.createServer(options, (cleartext) => {
 });
 server.listen(0, common.mustCall(function() {
   const socket = tls.connect({
-    port: this.address().port,
-    rejectUnauthorized: false
+    port: this.address().port
   }, common.mustCall(() => {
     const peerCert = socket.getPeerCertificate();
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/500](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/500)

To fix the issue, we will remove the `rejectUnauthorized: false` option and ensure that the test uses valid certificates for the TLS connection. The `ca` option is already provided in the `options` object, which specifies the trusted certificate authority. This should allow the connection to proceed securely without disabling certificate validation. 

We will:
1. Remove the `rejectUnauthorized: false` line from the `tls.connect` options.
2. Ensure that the test environment uses the provided certificates for authentication.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
