### PR TITLE
Potential fix for code scanning alert no. 493: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-over-http-tunnel.js
+++ b/test/parallel/test-tls-over-http-tunnel.js
@@ -145,9 +145,9 @@ proxy.listen(0, common.mustCall(() => {
       path: '/foo',
       key: key,
       cert: cert,
+      ca: cert,  // Use the certificate as the trusted CA
       socket: socket,  // reuse the socket
-      agent: false,
-      rejectUnauthorized: false
+      agent: false
     }, (res) => {
       assert.strictEqual(res.statusCode, 200);
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/493](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/493)

To fix the issue, we will remove the `rejectUnauthorized: false` option from the HTTPS request configuration. If the test requires a specific certificate to be trusted, we can use a custom CA (Certificate Authority) by specifying the `ca` option in the HTTPS request configuration. This approach ensures that the connection remains secure while allowing the test to function as intended.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
