### PR TITLE
Potential fix for code scanning alert no. 491: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-on-empty-socket.js
+++ b/test/parallel/test-tls-on-empty-socket.js
@@ -20,8 +20,7 @@ const server = tls.createServer({
   const socket = new net.Socket();
 
   const s = tls.connect({
-    socket: socket,
-    rejectUnauthorized: false
+    socket: socket
   }, function() {
     s.on('data', function(chunk) {
       out += chunk;


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/491](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/491)

To fix the issue, we will remove the `rejectUnauthorized: false` option and ensure that the connection validates certificates. If the test requires a specific certificate setup, we can use a self-signed certificate or a trusted certificate authority (CA) for testing purposes. This approach maintains the integrity of the TLS connection while still allowing the test to function as intended.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
