### PR TITLE
Potential fix for code scanning alert no. 489: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-net-socket-keepalive.js
+++ b/test/parallel/test-tls-net-socket-keepalive.js
@@ -33,7 +33,8 @@ const server = tls.createServer(options, common.mustCall((conn) => {
 
   const socket = tls.connect({
     socket: netSocket,
-    rejectUnauthorized: false,
+    rejectUnauthorized: true,
+    ca: [ca], // Ensure the CA is provided for certificate validation
   });
 
   const { port, address } = server.address();


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/489](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/489)

To fix the issue, we will replace `rejectUnauthorized: false` with `rejectUnauthorized: true` to ensure certificate validation is enabled. If the test requires a specific certificate to be trusted, we can configure the `ca` option to include the appropriate certificate authority (CA). This approach maintains the integrity of the TLS connection while still allowing the test to function as intended.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
