### PR TITLE
Potential fix for code scanning alert no. 488: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-max-send-fragment.js
+++ b/test/parallel/test-tls-max-send-fragment.js
@@ -70,7 +70,7 @@ const server = tls.createServer({
   c.end(buf);
 }).listen(0, common.mustCall(function() {
   const c = tls.connect(this.address().port, {
-    rejectUnauthorized: false
+    ca: [fixtures.readKey('agent1-cert.pem')]
   }, common.mustCall(function() {
     c.on('data', function(chunk) {
       assert(chunk.length <= maxChunk);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/488](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/488)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a proper setup that validates certificates. This can be achieved by using a self-signed certificate or a trusted CA for the test server and client. The `ca` option in the `tls.connect` call will be set to the server's certificate to ensure proper validation.

1. Generate or use an existing self-signed certificate for the test server.
2. Pass the server's certificate as the `ca` option in the `tls.connect` call to enable certificate validation.
3. Remove the `rejectUnauthorized: false` option.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
