### PR TITLE
Potential fix for code scanning alert no. 484: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-js-stream.js
+++ b/test/parallel/test-tls-js-stream.js
@@ -51,7 +51,7 @@ const server = tls.createServer({
 
   const socket = tls.connect({
     socket: p,
-    rejectUnauthorized: false
+    ca: [fixtures.readKey('agent1-cert.pem')] // Use self-signed certificate for testing
   }, common.mustCall(function() {
     console.log('client secure');
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/484](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/484)

To address the issue, the `rejectUnauthorized: false` option should be removed or replaced with a safer alternative. If disabling certificate validation is necessary for testing purposes, it should be explicitly documented in the code to clarify the intent. Alternatively, a self-signed certificate can be used, and the test can be configured to trust it. This approach maintains security while allowing the test to function as intended.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
