### PR TITLE
Potential fix for code scanning alert no. 482: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-invoke-queued.js
+++ b/test/parallel/test-tls-invoke-queued.js
@@ -47,7 +47,7 @@ const server = tls.createServer({
   server.close();
 })).listen(0, common.mustCall(function() {
   const c = tls.connect(this.address().port, {
-    rejectUnauthorized: false
+    ca: [fixtures.readKey('agent1-cert.pem')]
   }, common.mustCall(function() {
     c.on('data', function(chunk) {
       received += chunk;


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/482](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/482)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure configuration. Specifically, we will use a self-signed certificate for the server and configure the client to trust this certificate. This ensures that certificate validation is enabled while maintaining the integrity of the test.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
