### PR TITLE
Potential fix for code scanning alert no. 481: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-interleave.js
+++ b/test/parallel/test-tls-interleave.js
@@ -47,7 +47,7 @@ const server = tls.createServer(options, function(c) {
     c.write(str);
   });
 }).listen(0, common.mustCall(function() {
-  const connectOpts = { rejectUnauthorized: false };
+  const connectOpts = { ca: [fixtures.readKey('rsa_ca.crt')] };
   const c = tls.connect(this.address().port, connectOpts, function() {
     c.write('some client data');
     c.on('readable', function() {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/481](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/481)

To fix the issue, we will remove the `rejectUnauthorized: false` option from the `connectOpts` object. This will ensure that certificate validation is enabled by default. If the test requires a specific certificate to be trusted, we can explicitly provide the `ca` option in `connectOpts` to include the trusted CA certificate. This approach maintains the security of the TLS connection while still allowing the test to function as intended.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
