### PR TITLE
Potential fix for code scanning alert no. 480: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-inception.js
+++ b/test/parallel/test-tls-inception.js
@@ -43,7 +43,7 @@ const a = tls.createServer(options, function(socket) {
   const myOptions = {
     host: '127.0.0.1',
     port: b.address().port,
-    rejectUnauthorized: false
+    ca: fixtures.readKey('rsa_cert.crt')
   };
   const dest = net.connect(myOptions);
   dest.pipe(socket);
@@ -64,12 +64,12 @@ a.listen(0, function() {
     const myOptions = {
       host: '127.0.0.1',
       port: a.address().port,
-      rejectUnauthorized: false
+      ca: fixtures.readKey('rsa_cert.crt')
     };
     const socket = tls.connect(myOptions);
     const ssl = tls.connect({
       socket: socket,
-      rejectUnauthorized: false
+      ca: fixtures.readKey('rsa_cert.crt')
     });
     ssl.setEncoding('utf8');
     let buf = '';


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/480](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/480)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a secure alternative. Specifically, we will use self-signed certificates and configure the test to trust them explicitly. This involves:

1. Generating a self-signed certificate and private key (already present in the `fixtures` directory as `rsa_cert.crt` and `rsa_private.pem`).
2. Adding the `ca` (Certificate Authority) option to the TLS connection options, pointing to the self-signed certificate. This ensures the connection explicitly trusts the self-signed certificate without disabling validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
