### PR TITLE
Potential fix for code scanning alert no. 477: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-honorcipherorder.js
+++ b/test/parallel/test-tls-honorcipherorder.js
@@ -34,7 +34,7 @@ function test(honorCipherOrder, clientCipher, expectedCipher, defaultCiphers) {
   }));
   server.listen(0, localhost, mustCall(function() {
     const coptions = {
-      rejectUnauthorized: false,
+      ca: fixtures.readKey('agent2-cert.pem'),
       secureProtocol: SSL_Method
     };
     if (clientCipher) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/477](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/477)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a secure alternative. Specifically, we will use a self-signed certificate for the test server and configure the client to trust this certificate. This approach maintains the integrity of the test while ensuring that certificate validation is not disabled.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
