### PR TITLE
Potential fix for code scanning alert no. 476: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-handshake-exception.js
+++ b/test/parallel/test-tls-handshake-exception.js
@@ -28,7 +28,10 @@ if (process.argv[2] === 'child') {
 
   function onlisten() {
     const { port } = this.address();
-    https.get({ port, rejectUnauthorized: false });
+    https.get({ 
+      port, 
+      ca: cert // Trust the self-signed certificate
+    });
   }
 
   function onplaintext(c) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/476](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/476)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a secure alternative. Specifically, we will use a self-signed certificate for the test server and configure the client to trust this certificate. This approach ensures that certificate validation is still performed, but the test environment remains functional.

Steps to implement the fix:
1. Generate a self-signed certificate for the test server (if not already available).
2. Use the self-signed certificate in the server configuration.
3. Configure the client to trust the self-signed certificate by specifying the `ca` (Certificate Authority) option.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
