### PR TITLE
Potential fix for code scanning alert no. 474: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-getcipher.js
+++ b/test/parallel/test-tls-getcipher.js
@@ -48,7 +48,7 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
     host: '127.0.0.1',
     port: this.address().port,
     ciphers: 'AES256-SHA256',
-    rejectUnauthorized: false,
+    ca: fixtures.readKey('agent2-cert.pem'),
     maxVersion: 'TLSv1.2',
   }, common.mustCall(function() {
     const cipher = this.getCipher();
@@ -63,7 +63,7 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
     host: '127.0.0.1',
     port: this.address().port,
     ciphers: 'ECDHE-RSA-AES256-GCM-SHA384',
-    rejectUnauthorized: false,
+    ca: fixtures.readKey('agent2-cert.pem'),
     maxVersion: 'TLSv1.2',
   }, common.mustCall(function() {
     const cipher = this.getCipher();
@@ -87,7 +87,7 @@ tls.createServer({
     port: this.address().port,
     ciphers: 'TLS_AES_256_GCM_SHA384',
     maxVersion: 'TLSv1.3',
-    rejectUnauthorized: false
+    ca: fixtures.readKey('agent2-cert.pem')
   }, common.mustCall(() => {
     const cipher = client.getCipher();
     assert.strictEqual(cipher.name, 'TLS_AES_256_GCM_SHA384');


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/474](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/474)

To fix the issue, we should avoid disabling certificate validation by setting `rejectUnauthorized: true` (the default value). Instead, we can use a self-signed certificate for the test server and configure the client to trust this certificate. This ensures that the connection remains secure while still allowing the test to proceed as intended.

Steps to fix:
1. Generate a self-signed certificate if not already available in the `fixtures` directory.
2. Update the client connection options to include the `ca` property, pointing to the self-signed certificate.
3. Remove the `rejectUnauthorized: false` option from the client configurations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
