### PR TITLE
Potential fix for code scanning alert no. 473: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-getprotocol.js
+++ b/test/parallel/test-tls-getprotocol.js
@@ -40,7 +40,7 @@ const server = tls.createServer(serverConfig, common.mustCall(clientConfigs.leng
       host: common.localhostIPv4,
       port: server.address().port,
       ciphers: v.ciphers,
-      rejectUnauthorized: false,
+      ca: fixtures.readKey('agent2-cert.pem'),
       secureProtocol: v.secureProtocol
     }, common.mustCall(function() {
       assert.strictEqual(this.getProtocol(), v.version);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/473](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/473)

To fix the issue, we will replace `rejectUnauthorized: false` with a configuration that validates certificates. Specifically:
1. Generate a self-signed certificate for the server.
2. Configure the client to trust the server's certificate by using the `ca` option to specify the certificate authority (CA) certificate.
3. Remove the `rejectUnauthorized: false` option entirely.

This approach ensures that certificate validation is enabled, even in the test environment, while still allowing the test to function as intended.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
