### PR TITLE
Potential fix for code scanning alert no. 471: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-getcertificate-x509.js
+++ b/test/parallel/test-tls-getcertificate-x509.js
@@ -26,7 +26,7 @@ server.once('secureConnection', common.mustCall(function(socket) {
 server.listen(0, common.mustCall(function() {
   const socket = tls.connect({
     port: this.address().port,
-    rejectUnauthorized: false
+    ca: [fixtures.readKey('agent6-cert.pem')]
   }, common.mustCall(function() {
     const peerCert = socket.getPeerX509Certificate();
     assert(peerCert.issuerCertificate instanceof X509Certificate);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/471](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/471)

To fix the issue, we will replace `rejectUnauthorized: false` with a setup that validates certificates while still allowing the test to function. This can be achieved by using a self-signed certificate or a trusted test CA. The test server's certificate will be added to the client's trusted CA list, ensuring that the connection is secure and certificate validation is performed.

The changes involve:
1. Adding the server's certificate to the client's `ca` option to establish trust.
2. Removing the `rejectUnauthorized: false` option.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
