### PR TITLE
Potential fix for code scanning alert no. 470: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-exportkeyingmaterial.js
+++ b/test/parallel/test-tls-exportkeyingmaterial.js
@@ -95,7 +95,7 @@ const server = net.createServer(common.mustCall((s) => {
 })).listen(0, () => {
   const opts = {
     port: server.address().port,
-    rejectUnauthorized: false
+    ca: cert
   };
 
   tls.connect(opts, common.mustCall(function() { this.end(); }));


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/470](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/470)

To address the issue, we will replace `rejectUnauthorized: false` with a configuration that uses a self-signed certificate or a trusted CA for testing. This ensures that certificate validation is not disabled, even in the test environment. We will modify the `opts` object to include the `ca` property, pointing to the self-signed certificate used by the server. This approach maintains the integrity of the test while adhering to best practices for secure TLS communication.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
