### PR TITLE
Potential fix for code scanning alert no. 468: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-fast-writing.js
+++ b/test/parallel/test-tls-fast-writing.js
@@ -54,7 +54,7 @@ function onconnection(conn) {
 
 server.listen(0, function() {
   const chunk = Buffer.alloc(1024, 'x');
-  const opt = { port: this.address().port, rejectUnauthorized: false };
+  const opt = { port: this.address().port, ca: [fixtures.readKey('rsa_ca.crt')] };
   const conn = tls.connect(opt, function() {
     conn.on('drain', ondrain);
     write();


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/468](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/468)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a secure alternative. Specifically, we will provide the `ca` option with the trusted certificate authority (`rsa_ca.crt`) already available in the `fixtures` module. This ensures that the client validates the server's certificate during the TLS handshake, maintaining a secure connection even in the test environment.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
