### PR TITLE
Potential fix for code scanning alert no. 469: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-finished.js
+++ b/test/parallel/test-tls-finished.js
@@ -32,7 +32,7 @@ const server = tls.createServer({
 server.listen(0, common.mustCall(() => {
   const bob = tls.connect({
     port: server.address().port,
-    rejectUnauthorized: false
+    ca: [pem('agent1-cert')]
   }, common.mustCall(() => {
     msg.client = {
       alice: bob.getPeerFinished(),


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/469](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/469)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure configuration. Specifically, we will use a self-signed certificate for the server and configure the client to trust this certificate. This approach ensures that certificate validation remains enabled while still allowing the test to function as intended. The changes will involve:

1. Generating a self-signed certificate (if not already available in the `fixtures` directory).
2. Configuring the client to trust the self-signed certificate by specifying the `ca` option in the `tls.connect` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
