### PR TITLE
Potential fix for code scanning alert no. 466: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-disable-renegotiation.js
+++ b/test/parallel/test-tls-disable-renegotiation.js
@@ -45,7 +45,7 @@ const server = tls.Server(options, common.mustCall((socket) => {
 server.listen(0, common.mustCall(() => {
   const port = server.address().port;
   const options = {
-    rejectUnauthorized: false,
+    rejectUnauthorized: true, // Ensure certificate validation is enabled for secure connections.
     port
   };
   const client = tls.connect(options, common.mustCall(() => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/466](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/466)

To address the issue, we will replace `rejectUnauthorized: false` with a secure default (`rejectUnauthorized: true`) and add a comment explaining that certificate validation should not be disabled in production. If the test requires disabling certificate validation, we will ensure it is done in a controlled and documented manner, such as by using an environment variable or a specific test configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
