### PR TITLE
Potential fix for code scanning alert no. 464: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-delayed-attach.js
+++ b/test/parallel/test-tls-delayed-attach.js
@@ -61,7 +61,7 @@ const server = net.createServer(common.mustCall((c) => {
   }, 200);
 })).listen(0, common.mustCall(() => {
   const c = tls.connect(server.address().port, {
-    rejectUnauthorized: false
+    ca: [fixtures.readKey('agent1-cert.pem')]
   }, () => {
     c.end(sent);
   });


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/464](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/464)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure approach. Specifically, we will use a self-signed certificate or a trusted test certificate for the TLS connection. This ensures that certificate validation is enabled while still allowing the test to function as intended. The `ca` (Certificate Authority) option will be set to the certificate of the test server to establish trust.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
