### PR TITLE
Potential fix for code scanning alert no. 463: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-connect-stream-writes.js
+++ b/test/parallel/test-tls-connect-stream-writes.js
@@ -48,7 +48,7 @@ server.listen(0, function() {
 
   const socket = tls.connect({
     socket: p,
-    rejectUnauthorized: false
+    ca: [fixtures.readKey('rsa_ca.crt')]
   }, function() {
     for (let i = 0; i < 50; ++i) {
       socket.write(content);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/463](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/463)

To fix the issue, we will remove the `rejectUnauthorized: false` option from the `tls.connect` call. This will ensure that certificate validation is enabled. If the test requires a specific certificate to be trusted, we can configure the `ca` option to include the trusted certificate authority (CA) used by the server. This approach maintains the security of the TLS connection while allowing the test to function as intended.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
