### PR TITLE
Potential fix for code scanning alert no. 462: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-connect-simple.js
+++ b/test/parallel/test-tls-connect-simple.js
@@ -44,16 +44,14 @@ const server = tls.Server(options, common.mustCall(function(socket) {
 
 server.listen(0, function() {
   const client1options = {
-    port: this.address().port,
-    rejectUnauthorized: false
+    port: this.address().port
   };
   const client1 = tls.connect(client1options, common.mustCall(function() {
     client1.end();
   }));
 
   const client2options = {
-    port: this.address().port,
-    rejectUnauthorized: false
+    port: this.address().port
   };
   const client2 = tls.connect(client2options);
   client2.on('secureConnect', common.mustCall(function() {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/462](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/462)

To fix the issue, we will remove the `rejectUnauthorized: false` option from the `client1options` and `client2options` objects. This will restore the default behavior of validating certificates during TLS connections. If the test requires a specific certificate setup, we can configure the test to use a self-signed certificate or a trusted certificate authority (CA) for the server.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
