### PR TITLE
Potential fix for code scanning alert no. 460: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-connect-hwm-option.js
+++ b/test/parallel/test-tls-connect-hwm-option.js
@@ -24,7 +24,7 @@ server.listen(0, common.mustCall(() => {
   clients++;
   const highBob = tls.connect({
     port: server.address().port,
-    rejectUnauthorized: false,
+    ca: pem('agent1-cert'),
     highWaterMark: 128000,
   }, common.mustCall(() => {
     assert.strictEqual(highBob.readableHighWaterMark, 128000);
@@ -34,7 +34,7 @@ server.listen(0, common.mustCall(() => {
   clients++;
   const defaultHighBob = tls.connect({
     port: server.address().port,
-    rejectUnauthorized: false,
+    ca: pem('agent1-cert'),
     highWaterMark: undefined,
   }, common.mustCall(() => {
     assert.strictEqual(defaultHighBob.readableHighWaterMark, process.platform === 'win32' ? 16 * 1024 : 64 * 1024);
@@ -44,7 +44,7 @@ server.listen(0, common.mustCall(() => {
   clients++;
   const zeroHighBob = tls.connect({
     port: server.address().port,
-    rejectUnauthorized: false,
+    ca: pem('agent1-cert'),
     highWaterMark: 0,
   }, common.mustCall(() => {
     assert.strictEqual(zeroHighBob.readableHighWaterMark, 0);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/460](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/460)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a setup that uses valid certificates. This can be achieved by creating a self-signed certificate for the test server and ensuring that the client trusts this certificate. This approach maintains the integrity of the TLS connection while still allowing the tests to run in a controlled environment.

The changes involve:
1. Removing `rejectUnauthorized: false` from the client connection options.
2. Adding a `ca` (Certificate Authority) option to the client configuration, pointing to the server's certificate. This ensures that the client trusts the server's self-signed certificate.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
