### PR TITLE
Potential fix for code scanning alert no. 459: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-connect-pipe.js
+++ b/test/parallel/test-tls-connect-pipe.js
@@ -40,6 +40,7 @@ const server = tls.Server(options, common.mustCall(function(socket) {
   server.close();
 }));
 server.listen(common.PIPE, common.mustCall(function() {
+  // Intentionally disabling certificate validation for testing purposes only.
   const options = { rejectUnauthorized: false };
   const client = tls.connect(common.PIPE, options, common.mustCall(function() {
     client.end();


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/459](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/459)

To address the issue, we will explicitly document that the `rejectUnauthorized: false` setting is used intentionally for testing purposes. Additionally, we will ensure that this configuration is only applied in the test environment by adding a comment to clarify its purpose. This will prevent accidental misuse in production code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
