### PR TITLE
Potential fix for code scanning alert no. 457: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-connect-memleak.js
+++ b/test/parallel/test-tls-connect-memleak.js
@@ -48,7 +48,7 @@ const gcListener = { ongc() { collected = true; } };
 
   const sock = tls.connect(
     server.address().port,
-    { rejectUnauthorized: false },
+    { ca: fixtures.readKey('rsa_cert.crt') },
     common.mustCall(() => {
       assert.strictEqual(gcObject, gcObject); // Keep reference alive
       assert.strictEqual(collected, false);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/457](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/457)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a secure alternative. Specifically, we will configure the test to use a self-signed certificate or a trusted test certificate. This ensures that certificate validation is not disabled, even in the test environment. The `ca` (Certificate Authority) option will be used to provide the server's certificate to the client for validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
