### PR TITLE
Potential fix for code scanning alert no. 455: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-connect-given-socket.js
+++ b/test/parallel/test-tls-connect-given-socket.js
@@ -40,8 +40,8 @@ const server = tls.createServer(options, common.mustCall((socket) => {
   let waiting = 2;
   function establish(socket, calls) {
     const client = tls.connect({
-      rejectUnauthorized: false,
-      socket: socket
+      socket: socket,
+      ca: [fixtures.readKey('rsa_cert.crt')] // Use the server's certificate as the trusted CA
     }, common.mustCall(() => {
       let data = '';
       client.on('data', common.mustCall((chunk) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/455](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/455)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a secure alternative. Specifically, we will configure the test to use a self-signed certificate or a trusted CA. This ensures that certificate validation remains enabled while still allowing the test to function as intended. The `rejectUnauthorized` option will be removed or set to its default value (`true`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
