### PR TITLE
Potential fix for code scanning alert no. 454: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-connect-allow-half-open-option.js
+++ b/test/parallel/test-tls-connect-allow-half-open-option.js
@@ -24,6 +24,8 @@ const tls = require('tls');
 const server = tls.createServer({
   key: fixtures.readKey('agent1-key.pem'),
   cert: fixtures.readKey('agent1-cert.pem'),
+  ca: [fixtures.readKey('agent1-cert.pem')], // Add CA for self-signed certificate
+  requestCert: true, // Request client certificate for validation
 }, common.mustCall((socket) => {
   server.close();
 
@@ -47,7 +49,7 @@ const server = tls.createServer({
 server.listen(0, common.mustCall(() => {
   const socket = tls.connect({
     port: server.address().port,
-    rejectUnauthorized: false,
+    ca: [fixtures.readKey('agent1-cert.pem')], // Trust the self-signed certificate
     allowHalfOpen: true,
   }, common.mustCall(() => {
     let message = '';


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/454](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/454)

To fix the issue, we will replace `rejectUnauthorized: false` with a setup that uses a self-signed certificate. This involves creating a self-signed certificate for the test server and configuring the client to trust it. This approach maintains the integrity of certificate validation while still allowing the test to function as intended.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
