### PR TITLE
Potential fix for code scanning alert no. 453: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-connect-abort-controller.js
+++ b/test/parallel/test-tls-connect-abort-controller.js
@@ -20,7 +20,7 @@ server.listen(0, common.mustCall(async () => {
     port,
     host,
     signal,
-    rejectUnauthorized: false,
+    ca: fixtures.readKey('agent1-cert.pem'),
   });
 
   const assertAbort = async (socket, testName) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/453](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/453)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure alternative. Specifically, we will configure the test to use a self-signed certificate and explicitly trust it by providing the `ca` (Certificate Authority) option. This ensures that the connection remains secure while allowing the test to proceed without disabling certificate validation.

The changes will involve:
1. Adding the `ca` option to the `connectOptions` function, pointing to the self-signed certificate used by the server.
2. Removing the `rejectUnauthorized: false` option.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
