### PR TITLE
Potential fix for code scanning alert no. 449: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-close-event-after-write.js
+++ b/test/parallel/test-tls-close-event-after-write.js
@@ -32,7 +32,7 @@ const server = tls.createServer({
   test();
 }).listen(0, common.mustCall(function() {
   tls.connect(this.address().port, {
-    rejectUnauthorized: false
+    ca: fixtures.readKey('agent1-cert.pem')
   }, common.mustCall(function() {
     cconn = this;
     cconn.on('data', (d) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/449](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/449)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure alternative. Specifically, we will provide a trusted certificate authority (CA) for the test environment. This can be achieved by adding a `ca` property to the TLS connection options, pointing to a trusted CA certificate. This approach maintains security while allowing the test to proceed with a valid certificate.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
