### PR TITLE
Potential fix for code scanning alert no. 448: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-client-resume.js
+++ b/test/parallel/test-tls-client-resume.js
@@ -50,7 +50,7 @@ server.listen(0, common.mustCall(function() {
   let tls13;
   const client1 = tls.connect({
     port: this.address().port,
-    rejectUnauthorized: false
+    rejectUnauthorized: false // Used for testing purposes only. Do not use in production.
   }, common.mustCall(() => {
     tls13 = client1.getProtocol() === 'TLSv1.3';
     assert.strictEqual(client1.isSessionReused(), false);
@@ -94,7 +94,7 @@ server.listen(0, common.mustCall(function() {
 
     const opts = {
       port: server.address().port,
-      rejectUnauthorized: false,
+      rejectUnauthorized: false, // Used for testing purposes only. Do not use in production.
       session: session1,
     };
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/448](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/448)

To address the issue, we will add a comment explicitly stating that `rejectUnauthorized: false` is used only for testing purposes and should not be used in production. This will clarify the intent and prevent misuse in other contexts. Additionally, we will ensure that the test code is clearly marked as such.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
