### PR TITLE
Potential fix for code scanning alert no. 445: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-client-renegotiation-limit.js
+++ b/test/parallel/test-tls-client-renegotiation-limit.js
@@ -66,6 +66,8 @@ function test(next) {
     const options = {
       host: server.address().host,
       port: server.address().port,
+      // Disabling certificate validation for testing purposes only.
+      // Do not use this setting in production environments.
       rejectUnauthorized: false,
     };
     const client = tls.connect(options, spam);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/445](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/445)

To address the issue, we will explicitly document the reason for disabling certificate validation in the test file and ensure that it is clear this setting is only for testing purposes. Additionally, we will add a comment to emphasize that this should not be used in production. This approach maintains the functionality of the test while mitigating the risk of misuse.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
