### PR TITLE
Potential fix for code scanning alert no. 443: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-client-mindhsize.js
+++ b/test/parallel/test-tls-client-mindhsize.js
@@ -42,7 +42,7 @@ function test(size, err, next) {
     const client = tls.connect({
       minDHSize: minDHSize,
       port: this.address().port,
-      rejectUnauthorized: false,
+      ca: cert, // Use the server's certificate to validate the connection
       maxVersion: 'TLSv1.2',
     }, function() {
       nsuccess++;


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/443](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/443)

To address the issue, we will remove the `rejectUnauthorized: false` option from the `tls.connect` call. If the test requires bypassing certificate validation, we will replace it with a safer alternative, such as using a self-signed certificate and explicitly trusting it. This ensures that the test remains secure while achieving its intended purpose.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
