### PR TITLE
Potential fix for code scanning alert no. 441: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-client-destroy-soon.js
+++ b/test/parallel/test-tls-client-destroy-soon.js
@@ -49,7 +49,7 @@ const server = tls.createServer(options, common.mustCall(function(socket) {
 server.listen(0, common.mustCall(function() {
   const client = tls.connect({
     port: this.address().port,
-    rejectUnauthorized: false
+    ca: [fixtures.readKey('agent2-cert.pem')]
   }, common.mustCall(function() {
     let bytesRead = 0;
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/441](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/441)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure alternative. Specifically, we will use a self-signed certificate for the server and configure the client to trust this certificate. This approach maintains certificate validation while allowing the test to run in a controlled environment.

Steps:
1. Generate a self-signed certificate if not already available.
2. Add the self-signed certificate to the client's `ca` option to explicitly trust it.
3. Remove the `rejectUnauthorized: false` option.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
