### PR TITLE
Potential fix for code scanning alert no. 843: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-client-resume.js
+++ b/test/parallel/test-tls-client-resume.js
@@ -22,7 +22,7 @@
 'use strict';
 
 // Constant to explicitly indicate that certificate validation is disabled for testing purposes only.
-const TESTING_REJECT_UNAUTHORIZED = false;
+const TESTING_CA_CERT = fixtures.readKey('ca-cert.pem');
 
 // Check that the ticket from the first connection causes session resumption
 // when used to make a second connection.
@@ -53,7 +53,7 @@ server.listen(0, common.mustCall(function() {
   let tls13;
   const client1 = tls.connect({
     port: this.address().port,
-    rejectUnauthorized: TESTING_REJECT_UNAUTHORIZED // Used for testing purposes only. Do not use in production.
+    ca: TESTING_CA_CERT // Use a trusted CA certificate for testing purposes.
   }, common.mustCall(() => {
     tls13 = client1.getProtocol() === 'TLSv1.3';
     assert.strictEqual(client1.isSessionReused(), false);
@@ -97,7 +97,7 @@ server.listen(0, common.mustCall(function() {
 
     const opts = {
       port: server.address().port,
-      rejectUnauthorized: TESTING_REJECT_UNAUTHORIZED, // Used for testing purposes only. Do not use in production.
+      ca: TESTING_CA_CERT, // Use a trusted CA certificate for testing purposes.
       session: session1,
     };
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/843](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/843)

To address the issue, we will replace the `rejectUnauthorized: TESTING_REJECT_UNAUTHORIZED` configuration with a secure alternative. Specifically, we will configure the test to use a self-signed certificate and explicitly trust the certificate authority (CA) used to sign it. This approach maintains the security of the TLS connection while still allowing the test to function as intended.

The following changes will be made:
1. Replace the `rejectUnauthorized` option with a `ca` option that specifies the trusted CA certificate.
2. Update the test setup to include the CA certificate used to sign the server's certificate.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
