### PR TITLE
Potential fix for code scanning alert no. 437: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-alert-handling.js
+++ b/test/parallel/test-tls-alert-handling.js
@@ -60,9 +60,7 @@ server.on('tlsClientError', common.mustNotCall());
 server.on('error', common.mustNotCall());
 
 function sendClient() {
-  const client = tls.connect(server.address().port, {
-    rejectUnauthorized: false
-  });
+  const client = tls.connect(server.address().port, {});
   client.on('data', common.mustCall(function() {
     if (iter++ === 2) sendBADTLSRecord();
     if (iter < max_iter) {
@@ -86,7 +84,6 @@ function sendBADTLSRecord() {
   const socket = net.connect(server.address().port);
   const client = tls.connect({
     socket: socket,
-    rejectUnauthorized: false
   }, common.mustCall(function() {
     client.write('x');
     client.on('data', (data) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/437](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/437)

To fix the issue, we should avoid disabling certificate validation by removing the `rejectUnauthorized: false` option. Instead, we can use a self-signed certificate or a trusted certificate authority (CA) for testing purposes. This ensures that the TLS connection remains secure while still allowing the test to simulate the desired conditions.

In this specific case, we will:
1. Remove the `rejectUnauthorized: false` option from the `tls.connect` calls.
2. Ensure that the test uses the appropriate certificates (already loaded via `loadPEM`) to establish a secure connection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
