### PR TITLE
Potential fix for code scanning alert no. 434: Disabling certificate validation

### DIFF
--- a/test/parallel/test-tls-add-context.js
+++ b/test/parallel/test-tls-add-context.js
@@ -16,8 +16,7 @@ const serverOptions = {
   key: loadPEM('agent2-key'),
   cert: loadPEM('agent2-cert'),
   ca: [ loadPEM('ca2-cert') ],
-  requestCert: true,
-  rejectUnauthorized: false,
+  requestCert: true
 };
 
 let connections = 0;
@@ -44,8 +43,7 @@ server.addContext('context2', tls.createSecureContext(secureContext));
 const clientOptionsBase = {
   key: loadPEM('agent1-key'),
   cert: loadPEM('agent1-cert'),
-  ca: [ loadPEM('ca1-cert') ],
-  rejectUnauthorized: false,
+  ca: [ loadPEM('ca1-cert') ]
 };
 
 server.listen(0, common.mustCall(() => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/434](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/434)

To fix the issue, we will remove the `rejectUnauthorized: false` option from both `serverOptions` and `clientOptionsBase`. This will restore the default behavior of enabling certificate validation. If the test requires specific certificates to be trusted, we can ensure that the correct CA certificates are provided in the `ca` option, which is already present in the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
