### PR TITLE
Potential fix for code scanning alert no. 431: Disabling certificate validation

### DIFF
--- a/test/parallel/test-inspector-network-http.js
+++ b/test/parallel/test-inspector-network-http.js
@@ -161,7 +161,7 @@ async function testHttpsGet() {
     host: '127.0.0.1',
     port: httpsServer.address().port,
     path: '/hello-world',
-    rejectUnauthorized: false,
+    ca: fixtures.readKey('self-signed-cert.pem'), // Trust the self-signed certificate
     headers: requestHeaders,
   }, common.mustCall((res) => {
     // Dump the response.


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/431](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/431)

To fix the issue, we should replace the `rejectUnauthorized: false` option with a secure alternative. A common approach is to use a self-signed certificate for the HTTPS server and explicitly trust it during tests. This ensures that certificate validation is not disabled while still allowing the test to proceed.

Steps to implement the fix:
1. Generate a self-signed certificate for the HTTPS server used in the test.
2. Configure the HTTPS client to trust the self-signed certificate by providing the certificate authority (CA) or the certificate itself in the `ca` option.
3. Remove the `rejectUnauthorized: false` option.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
