### PR TITLE
Potential fix for code scanning alert no. 430: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-unix-socket-self-signed.js
+++ b/test/parallel/test-https-unix-socket-self-signed.js
@@ -22,6 +22,6 @@ const server = https.createServer(options, common.mustCall((req, res) => {
 server.listen(common.PIPE, common.mustCall(() => {
   https.get({
     socketPath: common.PIPE,
-    rejectUnauthorized: false
+    ca: fixtures.readKey('rsa_cert.crt')
   });
 }));


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/430](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/430)

To fix the issue, we will replace `rejectUnauthorized: false` with a more secure approach. Specifically, we will provide the `ca` (Certificate Authority) option in the HTTPS request configuration, explicitly trusting the self-signed certificate used in the test. This ensures that the test remains secure while still allowing the use of a self-signed certificate.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
