### PR TITLE
Potential fix for code scanning alert no. 429: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-truncate.js
+++ b/test/parallel/test-https-truncate.js
@@ -47,7 +47,7 @@ function httpsTest() {
   });
 
   server.listen(0, function() {
-    const opts = { port: this.address().port, rejectUnauthorized: false };
+    const opts = { port: this.address().port, ca: cert };
     https.get(opts).on('response', function(res) {
       test(res);
     });


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/429](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/429)

To fix the issue, the `rejectUnauthorized: false` option should be removed or replaced with a secure alternative. In this case, we can provide a trusted certificate for the client to validate the server during the test. This ensures the test remains secure while maintaining its functionality.

The fix involves:
1. Adding the `ca` (Certificate Authority) option to the client configuration (`opts`) to specify the trusted certificate.
2. Using the existing `agent1-cert.pem` file as the trusted certificate for the test.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
