### PR TITLE
Potential fix for code scanning alert no. 426: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-set-timeout-server.js
+++ b/test/parallel/test-https-set-timeout-server.js
@@ -231,7 +231,7 @@ test(function fastTimeout(cb) {
     const options = {
       port: server.address().port,
       allowHalfOpen: true,
-      rejectUnauthorized: false
+      ca: fixtures.readKey('agent1-cert.pem') // Use self-signed certificate
     };
     const c = tls.connect(options, () => {
       c.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/426](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/426)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure alternative. Specifically, we will configure the test to use a self-signed certificate for the server and ensure that the client trusts this certificate. This approach maintains the integrity of the test while adhering to secure practices.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
