### PR TITLE
Potential fix for code scanning alert no. 418: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-server-close-idle.js
+++ b/test/parallel/test-https-server-close-idle.js
@@ -37,11 +37,11 @@ server.listen(0, function() {
   let client2Closed = false;
 
   // Create a first request but never finish it
-  const client1 = connect({ port, rejectUnauthorized: false });
+  const client1 = connect({ port, ca: fixtures.readKey('agent1-cert.pem') });
 
   client1.on('connect', common.mustCall(() => {
     // Create a second request, let it finish but leave the connection opened using HTTP keep-alive
-    const client2 = connect({ port, rejectUnauthorized: false });
+    const client2 = connect({ port, ca: fixtures.readKey('agent1-cert.pem') });
     let response = '';
 
     client2.setEncoding('utf8');


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/418](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/418)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a secure alternative. Specifically, we will configure the test to use a self-signed certificate and ensure it is trusted by the client. This approach maintains the integrity of the TLS connection while allowing the test to proceed without disabling certificate validation.

Steps:
1. Use the existing self-signed certificate (`agent1-cert.pem`) and key (`agent1-key.pem`) for the server.
2. Add the server's certificate to the client's trusted CA list using the `ca` option in the `connect` method.
3. Remove the `rejectUnauthorized: false` option.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
