### PR TITLE
Potential fix for code scanning alert no. 416: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-socket-options.js
+++ b/test/parallel/test-https-socket-options.js
@@ -48,7 +48,7 @@ const server_http = http.createServer(function(req, res) {
 server_http.listen(0, function() {
   const req = http.request({
     port: this.address().port,
-    rejectUnauthorized: false
+    ca: fixtures.readKey('agent1-cert.pem')
   }, function(res) {
     server_http.close();
     res.resume();
@@ -72,7 +72,7 @@ const server_https = https.createServer(options, function(req, res) {
 server_https.listen(0, function() {
   const req = https.request({
     port: this.address().port,
-    rejectUnauthorized: false
+    ca: fixtures.readKey('agent1-cert.pem')
   }, function(res) {
     server_https.close();
     res.resume();


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/416](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/416)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a secure alternative. Since this is a test environment, we can use a self-signed certificate and ensure that the client trusts it. This approach maintains the integrity of the test while adhering to best practices for secure TLS connections.

The changes involve:
1. Removing the `rejectUnauthorized: false` option.
2. Adding the `ca` (Certificate Authority) option to the HTTPS request configuration, pointing to the self-signed certificate used by the server.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
