### PR TITLE
Potential fix for code scanning alert no. 414: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-server-options-server-response.js
+++ b/test/parallel/test-https-server-options-server-response.js
@@ -36,7 +36,7 @@ server.listen();
 server.on('listening', function makeRequest() {
   https.get({
     port: this.address().port,
-    rejectUnauthorized: false
+    ca: fixtures.readKey('ca1-cert.pem')
   }, (res) => {
     assert.strictEqual(res.statusCode, 200);
     res.on('end', () => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/414](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/414)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure alternative. Specifically, we will configure the test to use a trusted certificate authority (CA) for validation. This involves setting the `ca` option in the HTTPS request to the same CA certificate used by the server. This approach maintains certificate validation while ensuring the test environment functions correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
