### PR TITLE
Potential fix for code scanning alert no. 410: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-max-header-size-per-stream.js
+++ b/test/parallel/test-https-max-header-size-per-stream.js
@@ -78,7 +78,7 @@ const certFixture = {
   server.listen(0, common.mustCall(() => {
     const client = tls.connect({
       port: server.address().port,
-      rejectUnauthorized: false
+      ca: certFixture.cert
     });
     client.write(
       'GET / HTTP/1.1\r\n' +
@@ -105,7 +105,7 @@ const certFixture = {
   server.listen(0, common.mustCall(() => {
     const client = tls.connect({
       port: server.address().port,
-      rejectUnauthorized: false
+      ca: certFixture.cert
     });
     client.write(
       'GET / HTTP/1.1\r\n' +


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/410](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/410)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a secure alternative. Specifically, we will configure the test to use a self-signed certificate for the server and ensure the client trusts this certificate. This approach maintains the integrity of the test while adhering to best practices for TLS security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
