### PR TITLE
Potential fix for code scanning alert no. 408: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-request-arguments.js
+++ b/test/parallel/test-https-request-arguments.js
@@ -34,7 +34,7 @@ const options = {
         {
           hostname: 'localhost',
           port: server.address().port,
-          rejectUnauthorized: false
+          ca: fixtures.readKey('ca1-cert.pem')
         },
 
         common.mustCall((res) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/408](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/408)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a secure alternative. Specifically, we will configure the test to use a self-signed certificate and ensure that the `ca` (certificate authority) option is set to trust this certificate. This approach maintains the integrity of the test while avoiding the need to disable certificate validation.

- Update the `https.get` call to remove `rejectUnauthorized: false` and add the `ca` option, pointing to the self-signed certificate used by the server.
- Ensure that the `ca` option matches the certificate authority used in the server's configuration (`ca1-cert.pem`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
