### PR TITLE
Potential fix for code scanning alert no. 407: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-pfx.js
+++ b/test/parallel/test-https-pfx.js
@@ -39,7 +39,7 @@ const options = {
   pfx: pfx,
   passphrase: 'sample',
   requestCert: true,
-  rejectUnauthorized: false
+  ca: [fixtures.readKey('rsa_cert.pem')] // Trust the self-signed certificate
 };
 
 const server = https.createServer(options, function(req, res) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/407](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/407)

To fix the issue, we should avoid setting `rejectUnauthorized: false`. Instead, we can use a valid certificate for testing purposes. If the test specifically requires a self-signed certificate, we can configure the test to trust the self-signed certificate by providing it as a trusted CA. This approach maintains security while allowing the test to function as intended.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
