### PR TITLE
Potential fix for code scanning alert no. 406: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-max-headers-count.js
+++ b/test/parallel/test-https-max-headers-count.js
@@ -55,8 +55,7 @@ server.listen(0, common.mustCall(() => {
     const expected = maxAndExpected[responses][1];
     const req = https.request({
       port: server.address().port,
-      headers: headers,
-      rejectUnauthorized: false
+      headers: headers
     }, (res) => {
       assert.strictEqual(Object.keys(res.headers).length, expected);
       res.on('end', () => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/406](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/406)

To fix the issue, the `rejectUnauthorized: false` option should be removed or replaced with a secure alternative. In this case, the best approach is to use valid certificates for testing purposes. This ensures that the test environment mimics a secure production setup without compromising security.

The fix involves:
1. Removing the `rejectUnauthorized: false` option from the HTTPS request configuration.
2. Ensuring that the test server uses valid certificates, which are already provided in the `serverOptions` object (`agent1-key.pem` and `agent1-cert.pem`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
