### PR TITLE
Potential fix for code scanning alert no. 405: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-localaddress.js
+++ b/test/parallel/test-https-localaddress.js
@@ -55,8 +55,7 @@ server.listen(0, '127.0.0.1', function() {
     family: 4,
     path: '/',
     method: 'GET',
-    localAddress: '127.0.0.2',
-    rejectUnauthorized: false
+    localAddress: '127.0.0.2'
   };
 
   const req = https.request(options, function(res) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/405](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/405)

To fix the issue, the `rejectUnauthorized` option should be set to its default value (`true`) or removed entirely. If the test requires a trusted certificate, a self-signed certificate can be used instead. This ensures that the connection remains secure while still allowing the test to function correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
