### PR TITLE
Potential fix for code scanning alert no. 404: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-keep-alive-drop-requests.js
+++ b/test/parallel/test-https-keep-alive-drop-requests.js
@@ -36,7 +36,7 @@ server.listen(0, common.mustCall(() => {
   const socket = tls.connect(
     server.address().port,
     {
-      rejectUnauthorized: false
+      ca: readKey('agent1-cert.pem') // Use the server's certificate as the trusted CA
     },
     common.mustCall(() => {
       request(socket);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/404](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/404)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a configuration that uses a self-signed certificate or a trusted test certificate. This ensures that certificate validation is enabled while still allowing the test to function correctly. Specifically:
1. Add a `ca` (Certificate Authority) option to the TLS connection configuration, pointing to the self-signed certificate used by the server.
2. Remove the `rejectUnauthorized: false` option entirely, as it is no longer needed when the `ca` option is correctly configured.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
