### PR TITLE
Potential fix for code scanning alert no. 403: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-insecure-parse-per-stream.js
+++ b/test/parallel/test-https-insecure-parse-per-stream.js
@@ -78,7 +78,7 @@ const certFixture = {
   server.listen(0, common.mustCall(() => {
     const client = tls.connect({
       port: server.address().port,
-      rejectUnauthorized: false
+      ca: certFixture.ca
     });
     client.write(
       'GET / HTTP/1.1\r\n' +
@@ -105,7 +105,7 @@ const certFixture = {
   server.listen(0, common.mustCall(() => {
     const client = tls.connect({
       port: server.address().port,
-      rejectUnauthorized: false
+      ca: certFixture.ca
     });
     client.write(
       'GET / HTTP/1.1\r\n' +


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/403](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/403)

To fix the issue, the `rejectUnauthorized: false` setting should be removed or replaced with a secure alternative. If the test requires a connection to proceed without certificate validation, a self-signed certificate can be used instead. This ensures that the connection remains secure while allowing the test to simulate specific conditions.

The changes will involve:
1. Removing `rejectUnauthorized: false` from the `tls.connect` options.
2. Configuring the test to use the `ca` option with the self-signed certificate (`certFixture.ca`) to validate the server's certificate.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
