### PR TITLE
Potential fix for code scanning alert no. 399: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-host-headers.js
+++ b/test/parallel/test-https-host-headers.js
@@ -33,7 +33,7 @@ const httpsServer = https.createServer({
     path: `/${counter++}`,
     host: 'localhost',
     port: this.address().port,
-    rejectUnauthorized: false,
+    ca: fixtures.readKey('agent1-cert.pem'),
   }, cb).on('error', common.mustNotCall());
 
   https.request({
@@ -41,7 +41,7 @@ const httpsServer = https.createServer({
     path: `/${counter++}`,
     host: 'localhost',
     port: this.address().port,
-    rejectUnauthorized: false,
+    ca: fixtures.readKey('agent1-cert.pem'),
   }, cb).on('error', common.mustNotCall()).end();
 
   https.request({
@@ -49,7 +49,7 @@ const httpsServer = https.createServer({
     path: `/${counter++}`,
     host: 'localhost',
     port: this.address().port,
-    rejectUnauthorized: false,
+    ca: fixtures.readKey('agent1-cert.pem'),
   }, cb).on('error', common.mustNotCall()).end();
 
   https.request({
@@ -57,7 +57,7 @@ const httpsServer = https.createServer({
     path: `/${counter++}`,
     host: 'localhost',
     port: this.address().port,
-    rejectUnauthorized: false,
+    ca: fixtures.readKey('agent1-cert.pem'),
   }, cb).on('error', common.mustNotCall()).end();
 
   https.request({
@@ -65,7 +65,7 @@ const httpsServer = https.createServer({
     path: `/${counter++}`,
     host: 'localhost',
     port: this.address().port,
-    rejectUnauthorized: false,
+    ca: fixtures.readKey('agent1-cert.pem'),
   }, cb).on('error', common.mustNotCall()).end();
 
   https.get({
@@ -74,7 +74,7 @@ const httpsServer = https.createServer({
     host: 'localhost',
     setHost: false,
     port: this.address().port,
-    rejectUnauthorized: false,
+    ca: fixtures.readKey('agent1-cert.pem'),
   }, cb).on('error', common.mustNotCall());
 
   https.request({
@@ -84,7 +84,7 @@ const httpsServer = https.createServer({
     setHost: true,
     // agent: false,
     port: this.address().port,
-    rejectUnauthorized: false,
+    ca: fixtures.readKey('agent1-cert.pem'),
   }, cb).on('error', common.mustNotCall()).end();
 
   https.get({
@@ -93,7 +93,7 @@ const httpsServer = https.createServer({
     host: 'localhost',
     setHost: 0,
     port: this.address().port,
-    rejectUnauthorized: false,
+    ca: fixtures.readKey('agent1-cert.pem'),
   }, cb).on('error', common.mustNotCall());
 
   https.get({
@@ -102,7 +102,7 @@ const httpsServer = https.createServer({
     host: 'localhost',
     setHost: null,
     port: this.address().port,
-    rejectUnauthorized: false,
+    ca: fixtures.readKey('agent1-cert.pem'),
   }, cb).on('error', common.mustNotCall());
 }));
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/399](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/399)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a secure alternative. Specifically, we will configure the HTTPS requests to use a trusted certificate authority (CA) for validation. This involves providing the `ca` option in the HTTPS request configuration, pointing to the test server's certificate. This approach maintains security while allowing the tests to run successfully.

Steps to implement the fix:
1. Load the test server's certificate using the `fixtures.readKey` method.
2. Replace all instances of `rejectUnauthorized: false` with the `ca` option, specifying the loaded certificate.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
