### PR TITLE
Potential fix for code scanning alert no. 389: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-hwm.js
+++ b/test/parallel/test-https-hwm.js
@@ -42,7 +42,7 @@ const httpsServer = https.createServer({
     path: `/${counter++}`,
     host: 'localhost',
     port: this.address().port,
-    rejectUnauthorized: false,
+    // rejectUnauthorized is omitted to use the default value (true),
     highWaterMark: 128000,
   }, loadCallback(128000)).on('error', common.mustNotCall()).end();
 
@@ -51,7 +51,7 @@ const httpsServer = https.createServer({
     path: `/${counter++}`,
     host: 'localhost',
     port: this.address().port,
-    rejectUnauthorized: false,
+    // rejectUnauthorized is omitted to use the default value (true),
     highWaterMark: 0,
   }, loadCallback(0)).on('error', common.mustNotCall()).end();
 
@@ -60,7 +60,7 @@ const httpsServer = https.createServer({
     path: `/${counter++}`,
     host: 'localhost',
     port: this.address().port,
-    rejectUnauthorized: false,
+    // rejectUnauthorized is omitted to use the default value (true),
     highWaterMark: undefined,
   }, loadCallback(process.platform === 'win32' ? 16 * 1024 : 64 * 1024)).on('error', common.mustNotCall()).end();
 }));


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/389](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/389)

To fix the issue, we will remove the `rejectUnauthorized: false` option from the HTTPS requests. By default, `rejectUnauthorized` is set to `true`, which ensures that the server's certificate is validated. Since the server is running locally, we can use a trusted certificate or configure the test environment to accept the server's certificate without disabling validation.

Changes will be made to lines 45, 54, and 63, where `rejectUnauthorized: false` is explicitly set. These lines will be updated to remove the `rejectUnauthorized` option entirely, allowing the default behavior (`true`) to take effect.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
