### PR TITLE
Potential fix for code scanning alert no. 385: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-eof-for-eom.js
+++ b/test/parallel/test-https-eof-for-eom.js
@@ -68,7 +68,7 @@ server.listen(0, common.mustCall(function() {
   console.log('1) Making Request');
   https.get({
     port: this.address().port,
-    rejectUnauthorized: false
+    ca: fixtures.readKey('agent1-cert.pem')
   }, common.mustCall(function(res) {
     let bodyBuffer = '';
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/385](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/385)

To fix the issue, we should replace `rejectUnauthorized: false` with a secure alternative. The best approach is to use a trusted certificate authority or a self-signed certificate explicitly trusted for the test. This can be achieved by providing the `ca` option in the HTTPS request configuration, pointing to the certificate authority file used by the test server. This ensures that the client validates the server's certificate while maintaining the integrity of the test.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
