### PR TITLE
Potential fix for code scanning alert no. 383: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-connect-address-family.js
+++ b/test/parallel/test-https-connect-address-family.js
@@ -28,7 +28,7 @@ const https = require('https');
       host: HOSTNAME,
       port: this.address().port,
       family: 6,
-      rejectUnauthorized: false,
+      ca: fixtures.readKey('agent1-cert.pem'),
       lookup: common.mustCall((addr, opt, cb) => {
         assert.strictEqual(addr, HOSTNAME);
         assert.strictEqual(opt.family, 6);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/383](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/383)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure configuration. Specifically, we will use a self-signed certificate for the test server and configure the client to trust this certificate. This approach maintains the security of the connection while allowing the test to proceed as intended.

Steps:
1. Replace `rejectUnauthorized: false` with `ca: <certificate>` where `<certificate>` is the self-signed certificate used by the test server.
2. Ensure the test server's certificate is properly loaded using the `fixtures.readKey` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
