### PR TITLE
Potential fix for code scanning alert no. 382: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-close.js
+++ b/test/parallel/test-https-close.js
@@ -42,8 +42,7 @@ server.listen(0, () => {
     hostname: '127.0.0.1',
     port: server.address().port,
     path: '/',
-    method: 'GET',
-    rejectUnauthorized: false
+    method: 'GET'
   };
 
   const req = https.request(requestOptions, (res) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/382](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/382)

To fix the issue, the `rejectUnauthorized` option should be removed or explicitly set to `true`. This ensures that certificate validation is enabled, maintaining the security of the HTTPS connection. Since the code is part of a test file, the test should use valid certificates for the local server to avoid disabling validation. 

The fix involves:
1. Removing the `rejectUnauthorized: false` line from the `requestOptions` object.
2. Ensuring that the server uses valid certificates, which are already provided in the `options` object (`key` and `cert`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
