### PR TITLE
Potential fix for code scanning alert no. 381: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-client-resume.js
+++ b/test/parallel/test-https-client-resume.js
@@ -46,7 +46,7 @@ const server = https.createServer(options, common.mustCall((req, res) => {
 server.listen(0, common.mustCall(function() {
   const client1 = tls.connect({
     port: this.address().port,
-    rejectUnauthorized: false
+    rejectUnauthorized: true
   }, common.mustCall(() => {
     console.log('connect1');
     assert.strictEqual(client1.isSessionReused(), false);
@@ -61,7 +61,7 @@ server.listen(0, common.mustCall(function() {
 
     const opts = {
       port: server.address().port,
-      rejectUnauthorized: false,
+      rejectUnauthorized: true,
       session,
     };
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/381](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/381)

To fix the issue, we will replace `rejectUnauthorized: false` with `rejectUnauthorized: true` to ensure certificate validation is enabled. Since this is a test file, we will also ensure that the test uses a valid certificate (already provided in the `fixtures` directory). This change will maintain the integrity of the test while adhering to best practices for secure TLS connections.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
