### PR TITLE
Potential fix for code scanning alert no. 375: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-agent.js
+++ b/test/parallel/test-https-agent.js
@@ -53,7 +53,7 @@ server.listen(0, () => {
         https.get({
           path: '/',
           port: server.address().port,
-          rejectUnauthorized: false
+          ca: fixtures.readKey('ca-cert.pem')
         }, function(res) {
           res.resume();
           assert.strictEqual(res.statusCode, 200);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/375](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/375)

To fix the issue, we should avoid setting `rejectUnauthorized: false`. Instead, we can use a trusted certificate authority (CA) for testing purposes. This involves specifying the `ca` option in the HTTPS request configuration, which allows the client to validate the server's certificate against the provided CA. This approach maintains security while allowing the test to proceed.

Changes required:
1. Replace `rejectUnauthorized: false` with a secure configuration that includes a trusted CA.
2. Ensure the test uses a valid CA file from the fixtures directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
