### PR TITLE
Potential fix for code scanning alert no. 374: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-agent-sni.js
+++ b/test/parallel/test-https-agent-sni.js
@@ -47,7 +47,6 @@ server.listen(0, function() {
       port: this.address().port,
       host: '127.0.0.1',
       servername: `sni.${j}`,
-      rejectUnauthorized: false
     }, expectResponse(j));
   }
   https.get({
@@ -57,6 +56,5 @@ server.listen(0, function() {
     port: this.address().port,
     host: '127.0.0.1',
     servername: '',
-    rejectUnauthorized: false
   }, expectResponse(false));
 });


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/374](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/374)

To fix the issue, we will remove the `rejectUnauthorized: false` option from the HTTPS request configuration. This will ensure that certificate validation is enabled, which is the default behavior. If the test requires specific certificates, we can provide valid test certificates instead of disabling validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
