### PR TITLE
Potential fix for code scanning alert no. 372: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-agent-session-eviction.js
+++ b/test/parallel/test-https-agent-session-eviction.js
@@ -30,7 +30,7 @@ function first(server) {
   const port = server.address().port;
   const req = https.request({
     port: port,
-    rejectUnauthorized: false
+    ca: readKey('custom-ca-cert.pem')
   }, function(res) {
     res.resume();
 
@@ -57,7 +57,7 @@ function second(server, session) {
   const req = https.request({
     port: server.address().port,
     ciphers: (common.hasOpenSSL(3, 1) ? 'DEFAULT:@SECLEVEL=0' : 'DEFAULT'),
-    rejectUnauthorized: false
+    ca: readKey('custom-ca-cert.pem')
   }, function(res) {
     res.resume();
   });


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/372](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/372)

To fix the issue, we should avoid setting `rejectUnauthorized: false`. Instead, we can use a custom CA for testing purposes. This ensures that the server's certificate is validated against the custom CA, maintaining security while allowing the test to proceed. 

The changes involve:
1. Generating a custom CA certificate and using it in the test.
2. Adding the `ca` option to the HTTPS request configuration to specify the custom CA.
3. Removing the `rejectUnauthorized: false` option.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
