### PR TITLE
Potential fix for code scanning alert no. 370: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-agent-keylog.js
+++ b/test/parallel/test-https-agent-keylog.js
@@ -20,14 +20,14 @@ const server = https.createServer({
 }).listen(() => {
   https.get({
     port: server.address().port,
-    rejectUnauthorized: false,
+    // Certificate validation enabled by default
   }, (res) => {
     res.resume();
     res.on('end', () => {
       // Trigger TLS connection reuse
       https.get({
         port: server.address().port,
-        rejectUnauthorized: false,
+        // Certificate validation enabled by default
       }, (res) => {
         server.close();
         res.resume();


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/370](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/370)

To address the issue, the `rejectUnauthorized: false` option should be removed or replaced with a secure alternative. If the test requires bypassing certificate validation, it should use a trusted certificate or explicitly document the reason for disabling validation. The best approach is to ensure that the test uses proper certificates and enables validation (`rejectUnauthorized: true`).

Changes will be made to the lines where `rejectUnauthorized: false` is set (lines 23 and 30). The `rejectUnauthorized` option will be removed, as its default value is `true`, ensuring certificate validation is enabled.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
