### PR TITLE
Potential fix for code scanning alert no. 368: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-agent-disable-session-reuse.js
+++ b/test/parallel/test-https-agent-disable-session-reuse.js
@@ -31,8 +31,7 @@ const server = https.createServer(options, function(req, res) {
   function request() {
     const options = {
       agent: agent,
-      port: server.address().port,
-      rejectUnauthorized: false
+      port: server.address().port
     };
 
     https.request(options, function(res) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/368](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/368)

To fix the issue, we should remove `rejectUnauthorized: false` and ensure that the test uses valid certificates for authentication. This can be achieved by setting up a trusted certificate authority or using self-signed certificates that are explicitly trusted within the test environment. The `rejectUnauthorized` option should either be omitted (defaulting to `true`) or explicitly set to `true`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
