### PR TITLE
Potential fix for code scanning alert no. 367: Disabling certificate validation

### DIFF
--- a/test/parallel/test-https-abortcontroller.js
+++ b/test/parallel/test-https-abortcontroller.js
@@ -27,7 +27,7 @@ const options = {
       port,
       path: '/',
       method: 'GET',
-      rejectUnauthorized: false,
+
       signal: ac.signal,
     });
     assert.strictEqual(getEventListeners(ac.signal, 'abort').length, 1);
@@ -54,7 +54,7 @@ const options = {
       port,
       path: '/',
       method: 'GET',
-      rejectUnauthorized: false,
+
       signal,
     });
     assert.strictEqual(getEventListeners(ac.signal, 'abort').length, 1);
@@ -82,7 +82,7 @@ const options = {
       port,
       path: '/',
       method: 'GET',
-      rejectUnauthorized: false,
+
       signal,
     });
     assert.strictEqual(getEventListeners(ac.signal, 'abort').length, 0);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/367](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/367)

To fix the issue, we will remove the `rejectUnauthorized: false` option and ensure that the test uses a valid certificate. Since the test already uses a key and certificate (`agent1-key.pem` and `agent1-cert.pem`), we can rely on these for secure communication. The `rejectUnauthorized` option will be omitted, allowing it to default to `true`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
