### PR TITLE
Potential fix for code scanning alert no. 360: Disabling certificate validation

### DIFF
--- a/test/parallel/test-http2-connect.js
+++ b/test/parallel/test-http2-connect.js
@@ -97,7 +97,7 @@ const { connect: tlsConnect } = require('tls');
     const clientOptions = {
       ALPNProtocols: ['h2'],
       port,
-      rejectUnauthorized: false
+      ca: fixtures.readKey('agent1-cert.pem')
     };
     const socket = tlsConnect(clientOptions, mustCall(onSocketConnect));
   }));


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/360](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/360)

To fix the issue, we should avoid setting `rejectUnauthorized: false`. Instead, we can use a trusted self-signed certificate for testing purposes. This involves specifying the `ca` (Certificate Authority) option in the `tlsConnect` configuration, which allows the client to validate the server's certificate against the provided CA. This approach maintains security while still allowing the test to proceed with a controlled certificate.

Changes to make:
1. Replace `rejectUnauthorized: false` with `ca: fixtures.readKey('agent1-cert.pem')` to use the trusted self-signed certificate.
2. Ensure the test setup includes the necessary certificate files.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
