### PR TITLE
Potential fix for code scanning alert no. 359: Disabling certificate validation

### DIFF
--- a/test/parallel/test-http2-connect-tls-with-delay.js
+++ b/test/parallel/test-http2-connect-tls-with-delay.js
@@ -23,7 +23,7 @@ server.listen(0, '127.0.0.1', common.mustCall(() => {
     host: '127.0.0.1',
     servername: 'localhost',
     port: server.address().port,
-    rejectUnauthorized: false
+    ca: fixtures.readKey('agent1-cert.pem')
   };
 
   const socket = tls.connect(options, async () => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/359](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/359)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure alternative. Specifically, we will configure the test to use a trusted certificate authority (CA) by adding the `ca` option to the TLS connection options. This ensures that the certificate validation process is not bypassed, even in the test environment. The `ca` option will point to the same certificate used by the server, ensuring that the client trusts the server's certificate.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
