### PR TITLE
Potential fix for code scanning alert no. 358: Disabling certificate validation

### DIFF
--- a/test/parallel/test-http2-client-jsstream-destroy.js
+++ b/test/parallel/test-http2-client-jsstream-destroy.js
@@ -35,7 +35,7 @@ class JSSocket extends Duplex {
 
 server.listen(0, common.mustCall(function() {
   const socket = tls.connect({
-    rejectUnauthorized: false,
+    ca: fixtures.readKey('agent1-cert.pem'),
     host: 'localhost',
     port: this.address().port,
     ALPNProtocols: ['h2']


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/358](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/358)

To fix the issue, we will replace the `rejectUnauthorized: false` option with a secure alternative. Specifically, we will configure the `tls.connect` method to use a self-signed certificate or a trusted CA for testing purposes. This ensures that certificate validation is enabled while still allowing the test to function correctly. We will use the `ca` option to specify the trusted certificate authority.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
