### PR TITLE
Potential fix for code scanning alert no. 355: Disabling certificate validation

### DIFF
--- a/test/parallel/test-http2-allow-http1.js
+++ b/test/parallel/test-http2-allow-http1.js
@@ -34,7 +34,7 @@ const http2 = require('http2');
     https.get(
       `https://localhost:${server.address().port}`,
       {
-        rejectUnauthorized: false,
+        ca: fixtures.readKey('agent1-cert.pem'),
         headers: { connection: 'keep-alive' },
       },
       resolve


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/355](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/355)

To fix the issue, we should avoid setting `rejectUnauthorized: false`. Instead, we can provide a trusted CA certificate to validate the server's certificate. This approach ensures that the test remains secure while still allowing the connection to succeed. The fix involves replacing the `rejectUnauthorized: false` option with a `ca` option that specifies the trusted CA certificate.

The required changes are:
1. Read the trusted CA certificate using the `fixtures.readKey` method.
2. Pass the `ca` option to the HTTPS request configuration instead of `rejectUnauthorized: false`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
