### PR TITLE
Potential fix for code scanning alert no. 354: Disabling certificate validation

### DIFF
--- a/test/parallel/test-http-request-agent.js
+++ b/test/parallel/test-http-request-agent.js
@@ -27,8 +27,7 @@ server.listen(0, common.mustCall(function() {
   https.get({
     agent: false,
     path: '/',
-    port: this.address().port,
-    rejectUnauthorized: false
+    port: this.address().port
   }, common.mustCall(function(res) {
     console.error(res.statusCode, res.headers);
     res.resume();


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/354](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/354)

To fix the issue, the `rejectUnauthorized` option should be removed or explicitly set to `true`. This ensures that the HTTPS connection validates the server's certificate, maintaining the security of the connection. If the test requires bypassing certificate validation, it should be clearly documented, and alternative secure methods (e.g., using a trusted test certificate) should be considered.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
