### PR TITLE
Potential fix for code scanning alert no. 347: Disabling certificate validation

### DIFF
--- a/test/parallel/test-double-tls-server.js
+++ b/test/parallel/test-double-tls-server.js
@@ -62,7 +62,7 @@ const serverReplaySize = 2 * 1024 * 1024;
     const clientTlsSock = tls.connect({
       host: '127.0.0.1',
       port: server.address().port,
-      rejectUnauthorized: false,
+      ca: [fixtures.readKey('agent1-cert.pem')],
     });
 
     const recv = [];


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/347](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/347)

To fix the issue, the `rejectUnauthorized: false` setting should be removed or replaced with a secure alternative. The best approach is to use a trusted test certificate authority (CA) and ensure that the client validates the server's certificate. This can be achieved by providing the `ca` option in the `tls.connect` configuration, pointing to the trusted CA certificate used by the server.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
