### PR TITLE
Potential fix for code scanning alert no. 346: Disabling certificate validation

### DIFF
--- a/test/parallel/test-double-tls-client.js
+++ b/test/parallel/test-double-tls-client.js
@@ -33,7 +33,7 @@ function client() {
   const down = tls.connect({
     host: '127.0.0.1',
     port: server.address().port,
-    rejectUnauthorized: false
+    rejectUnauthorized: true
   }).on('secureConnect', () => {
     down.write(HEAD, common.mustSucceed());
 
@@ -52,7 +52,7 @@ function client() {
     // Aborted
     tls.connect({
       socket: down,
-      rejectUnauthorized: false
+      rejectUnauthorized: true
     });
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/346](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/346)

To fix the issue, we should remove the `rejectUnauthorized: false` option and ensure that certificate validation is enabled. If the test requires a specific certificate setup, we can use valid certificates or self-signed certificates that are explicitly trusted. This maintains the integrity of the TLS connection while allowing the test to proceed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
