### PR TITLE
Potential fix for code scanning alert no. 343: Disabling certificate validation

### DIFF
--- a/test/parallel/test-async-wrap-tlssocket-asyncreset.js
+++ b/test/parallel/test-async-wrap-tlssocket-asyncreset.js
@@ -29,7 +29,7 @@ server.listen(
     const clientOptions = {
       agent: new https.Agent({
         keepAlive: true,
-        rejectUnauthorized: false
+        ca: fixtures.readKey('ca1-cert.pem')
       }),
       port: port
     };


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/343](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/343)

To fix the issue, the `rejectUnauthorized: false` setting should be removed or replaced with a secure alternative. The best approach is to use a valid certificate authority (CA) for testing purposes. The `ca` option in the `https.Agent` configuration can be set to the trusted CA used by the test server. This ensures that the client validates the server's certificate while maintaining the integrity of the test.

Changes will be made to the `clientOptions` object to remove `rejectUnauthorized: false` and add the `ca` option, which references the same CA used by the server.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
