### PR TITLE
Potential fix for code scanning alert no. 342: Disabling certificate validation

### DIFF
--- a/test/fixtures/GH-892-request.js
+++ b/test/fixtures/GH-892-request.js
@@ -33,7 +33,7 @@ var gotResponse = false;
 var options = {
   method: 'POST',
   port: PORT,
-  rejectUnauthorized: false
+  rejectUnauthorized: true
 };
 
 var req = https.request(options, function(res) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/342](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/342)

To fix the issue, the `rejectUnauthorized` option should be removed or explicitly set to `true`. This ensures that certificate validation is enabled, maintaining the security of the HTTPS connection. If the test requires a specific certificate, a trusted certificate authority (CA) or a self-signed certificate can be used, and the `ca` option can be configured accordingly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
