### PR TITLE
Potential fix for code scanning alert no. 341: Disabling certificate validation

### DIFF
--- a/test/async-hooks/test-tlswrap.js
+++ b/test/async-hooks/test-tlswrap.js
@@ -37,7 +37,7 @@ function onlistening() {
   // Creating client and connecting it to server
   //
   tls
-    .connect(server.address().port, { rejectUnauthorized: false })
+    .connect(server.address().port, { rejectUnauthorized: true })
     .on('secureConnect', common.mustCall(onsecureConnect));
 
   const as = hooks.activitiesOfTypes('TLSWRAP');


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/341](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/341)

To fix the issue, the `rejectUnauthorized` option should be set to its default value (`true`) or explicitly set to `true`. This ensures that certificate validation is enabled, making the TLS connection secure. If the test requires disabling validation for specific reasons, it should be documented with a clear explanation, and alternative secure methods should be considered.

The fix involves modifying the `tls.connect` call on line 40 to remove `rejectUnauthorized: false` or set it to `true`. No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
