### PR TITLE
Potential fix for code scanning alert no. 340: Disabling certificate validation

### DIFF
--- a/test/async-hooks/test-graph.tls-write.js
+++ b/test/async-hooks/test-graph.tls-write.js
@@ -32,7 +32,9 @@ function onlistening() {
   // Creating client and connecting it to server
   //
   tls
-    .connect(server.address().port, { rejectUnauthorized: false })
+    .connect(server.address().port, { 
+      ca: fixtures.readKey('rsa_cert.crt') // Trust the server's self-signed certificate
+    })
     .on('secureConnect', common.mustCall(onsecureConnect));
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/340](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/340)

To fix the issue, we will replace `rejectUnauthorized: false` with a secure alternative. Specifically, we will use a self-signed certificate for the server and configure the client to trust this certificate explicitly. This approach maintains the integrity of the test while ensuring that certificate validation is not disabled.

Steps:
1. Generate a self-signed certificate for the server (if not already available).
2. Update the client connection options to include the `ca` property, pointing to the self-signed certificate. This ensures the client explicitly trusts the server's certificate.
3. Remove the `rejectUnauthorized: false` option.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
