### PR TITLE
Potential fix for code scanning alert no. 338: Disabling certificate validation

### DIFF
--- a/test/addons/openssl-key-engine/test.js
+++ b/test/addons/openssl-key-engine/test.js
@@ -41,7 +41,8 @@ const server = https.createServer(serverOptions, common.mustCall((req, res) => {
     privateKeyEngine: engine,
     privateKeyIdentifier: 'dummykey',
     cert: agentCert,
-    rejectUnauthorized: false, // Prevent failing on self-signed certificates
+    ca: agentCa, // Trust the self-signed certificate
+    rejectUnauthorized: true,
     headers: {},
   };
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/338](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/338)

To fix the issue, we should avoid disabling certificate validation by setting `rejectUnauthorized: true`. Instead, we can configure the client to trust the self-signed certificate used by the server. This can be achieved by adding the server's CA certificate (`agentCa`) to the client's `ca` option. This ensures that the client validates the server's certificate while still allowing the use of self-signed certificates.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
