### PR TITLE
Potential fix for code scanning alert no. 669: Multiplication result converted to larger type

### DIFF
--- a/deps/icu-small/source/tools/toolutil/toolutil.cpp
+++ b/deps/icu-small/source/tools/toolutil/toolutil.cpp
@@ -445,7 +445,7 @@ utm_allocN(UToolMemory *mem, int32_t n) {
     if(utm_hasCapacity(mem, newIndex)) {
         p=(char *)mem->array+oldIndex*mem->size;
         mem->idx=newIndex;
-        uprv_memset(p, 0, n*mem->size);
+        uprv_memset(p, 0, static_cast<size_t>(n) * mem->size);
     }
     return p;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/669](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/669)

To fix the issue, we need to ensure that the multiplication `n * mem->size` is performed in a type large enough to avoid overflow. This can be achieved by casting one of the operands to `size_t` before the multiplication. This ensures that the multiplication is performed in the `size_t` type, which is typically larger than `int32_t` and can safely hold the result.

The specific change involves modifying line 448 to cast `n` or `mem->size` to `size_t` before the multiplication. This change is localized and does not affect the rest of the program's functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
