### PR TITLE
Potential fix for code scanning alert no. 663: Potentially overflowing call to snprintf

### DIFF
--- a/deps/cares/src/lib/inet_ntop.c
+++ b/deps/cares/src/lib/inet_ntop.c
@@ -198,7 +198,14 @@ static const char *inet_ntop6(const unsigned char *src, char *dst, size_t size)
       tp += ares_strlen(tp);
       break;
     }
-    tp += snprintf(tp, sizeof(tmp) - (size_t)(tp - tmp), "%x", words[i]);
+    {
+      int n = snprintf(tp, sizeof(tmp) - (size_t)(tp - tmp), "%x", words[i]);
+      if (n < 0 || (size_t)n >= sizeof(tmp) - (size_t)(tp - tmp)) {
+        SET_SOCKERRNO(ENOSPC);
+        return NULL;
+      }
+      tp += n;
+    }
   }
   /* Was it a trailing run of 0x00's? */
   if (best.base != -1 &&


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/663](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/663)

To fix the issue, the return value of `snprintf` should be checked to ensure it is non-negative and does not exceed the remaining buffer size. If the return value indicates an error or an overflow, the function should handle it gracefully (e.g., by returning `NULL` or setting an appropriate error code). This ensures that the buffer remains within bounds and prevents undefined behavior.

The fix involves:
1. Capturing the return value of `snprintf` in a variable.
2. Validating the return value to ensure it is within the bounds of the remaining buffer size.
3. Breaking out of the loop or returning an error if the validation fails.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
