### PR TITLE
Potential fix for code scanning alert no. 845: Disabling certificate validation

### DIFF
--- a/test/addons/openssl-client-cert-engine/test.js
+++ b/test/addons/openssl-client-cert-engine/test.js
@@ -39,8 +39,8 @@ const server = https.createServer(serverOptions, common.mustCall((req, res) => {
     port: server.address().port,
     path: '/test',
     clientCertEngine: engine,  // `engine` will provide key+cert
-    rejectUnauthorized: false, // NOTE: This is intentionally set to false for testing purposes only.
-                               //       Do not use this configuration in production environments.
+    rejectUnauthorized: process.env.NODE_ENV === 'test' ? false : true, // Ensure this is only used in test environments.
+                               // WARNING: Do not use `rejectUnauthorized: false` in production environments.
     headers: {},
   };
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/845](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/845)

To address the issue, we will ensure that the `rejectUnauthorized: false` setting is only applied in a controlled test environment. This can be achieved by wrapping the configuration in a conditional check that explicitly verifies the environment is a test environment. Additionally, we will add a stronger warning in the comments to discourage misuse of this configuration in other contexts.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
