### PR TITLE
Potential fix for code scanning alert no. 236: Use of a weak cryptographic key

### DIFF
--- a/benchmark/crypto/keygen.js
+++ b/benchmark/crypto/keygen.js
@@ -17,7 +17,7 @@ const methods = {
     bench.start();
     for (let i = 0; i < n; ++i) {
       generateKeyPairSync('rsa', {
-        modulusLength: 1024,
+        modulusLength: 2048,
         publicExponent: 0x10001,
       });
     }
@@ -34,7 +34,7 @@ const methods = {
     bench.start();
     for (let i = 0; i < n; ++i)
       generateKeyPair('rsa', {
-        modulusLength: 512,
+        modulusLength: 2048,
         publicExponent: 0x10001,
       }, done);
   },


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/236](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/236)

To fix the issue, the RSA key generation should use a `modulusLength` of at least 2048 bits, as recommended by modern cryptographic standards. This change should be applied to both the `rsaSync` and `rsaAsync` methods. For the `rsaAsync` method, the `modulusLength` should also be updated to 2048 bits to ensure consistency and security. These changes will ensure that the generated keys meet current security standards without altering the functionality of the benchmarking code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
