### PR TITLE
Potential fix for code scanning alert no. 599: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/deps/icu-small/source/common/rbbi_cache.cpp
+++ b/deps/icu-small/source/common/rbbi_cache.cpp
@@ -130,7 +130,7 @@ void RuleBasedBreakIterator::DictionaryCache::populateDictionary(int32_t startPo
     int32_t rangeStart = startPos;
     int32_t rangeEnd = endPos;
 
-    uint16_t    category;
+    uint32_t    category;
     int32_t     current;
     UErrorCode  status = U_ZERO_ERROR;
     int32_t     foundBreakCount = 0;


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/599](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/599)

To fix the issue, the type of `category` should be widened to match the type of `dictStart` (`uint32_t`). This can be achieved by changing the declaration of `category` from `uint16_t` to `uint32_t`. This ensures that the comparison `category < dictStart` is performed between two values of the same type, eliminating the risk of overflow or unexpected behavior.

The changes should be made in the file `deps/icu-small/source/common/rbbi_cache.cpp`:
- Update the declaration of `category` on line 133 to use `uint32_t` instead of `uint16_t`.

No additional methods, imports, or definitions are required to implement this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
