### PR TITLE
Potential fix for code scanning alert no. 314: Incomplete string escaping or encoding

### DIFF
--- a/test/parallel/test-repl-load-multiline-no-trailing-newline.js
+++ b/test/parallel/test-repl-load-multiline-no-trailing-newline.js
@@ -9,7 +9,7 @@ common.skipIfDumbTerminal();
 
 const command = `.load ${fixtures.path('repl-load-multiline-no-trailing-newline.js')}`;
 const terminalCode = '\u001b[1G\u001b[0J \u001b[1G';
-const terminalCodeRegex = new RegExp(terminalCode.replace(/\[/g, '\\['), 'g');
+const terminalCodeRegex = new RegExp(terminalCode.replace(/\\/g, '\\\\').replace(/\[/g, '\\['), 'g');
 
 const expected = `${command}
 // The lack of a newline at the end of this file is intentional.


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/314](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/314)

To fix the issue, we need to ensure that backslashes in the `terminalCode` string are properly escaped before creating the regular expression. This can be achieved by adding a step to replace backslashes (`\`) with double backslashes (`\\`) in the `replace` chain. This ensures that all occurrences of backslashes are escaped, making the code robust against future changes to `terminalCode`.

The updated code will replace backslashes first, followed by replacing the `[` character. This ensures that both meta-characters are properly escaped.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
