### PR TITLE
Potential fix for code scanning alert no. 673: Multiplication result converted to larger type

### DIFF
--- a/deps/openssl/openssl/crypto/asn1/a_time.c
+++ b/deps/openssl/openssl/crypto/asn1/a_time.c
@@ -248,7 +248,7 @@ int ossl_asn1_time_to_tm(struct tm *tm, const ASN1_TIME *d)
             }
             o++;
         }
-        if (offset && !OPENSSL_gmtime_adj(&tmp, 0, offset * offsign))
+        if (offset && !OPENSSL_gmtime_adj(&tmp, 0, (long)offset * offsign))
             goto err;
     } else {
         /* not Z, or not +/- in non-strict mode */


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/673](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/673)

To fix the issue, the multiplication `offset * offsign` should be performed using the `long` type to ensure that no overflow occurs during the calculation. This can be achieved by explicitly casting one of the operands (`offset` or `offsign`) to `long` before the multiplication. This ensures that the multiplication is performed using the `long` type, avoiding overflow.

The specific changes are:
1. Cast `offset` to `long` in the multiplication `offset * offsign` on line 251.
2. Ensure no other functionality is altered.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
