### PR TITLE
Potential fix for code scanning alert no. 208: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-keygen-rfc8017-9-1.js
+++ b/test/parallel/test-crypto-keygen-rfc8017-9-1.js
@@ -15,7 +15,7 @@ const {
 {
 
   generateKeyPair('rsa-pss', {
-    modulusLength: 512,
+    modulusLength: 2048,
     hashAlgorithm: 'sha256',
     saltLength: 16
   }, common.mustSucceed((publicKey, privateKey) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/208](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/208)

To fix the issue, the `modulusLength` parameter in the `generateKeyPair` function should be updated from 512 to 2048. This ensures compliance with modern cryptographic standards while maintaining the functionality of the test. The change is localized to the test file and does not require any additional imports or modifications to other parts of the codebase.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
