### PR TITLE
Potential fix for code scanning alert no. 209: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-keygen-sync.js
+++ b/test/parallel/test-crypto-keygen-sync.js
@@ -21,7 +21,7 @@ const {
 {
   const ret = generateKeyPairSync('rsa', {
     publicExponent: 3,
-    modulusLength: 512,
+    modulusLength: 2048,
     publicKeyEncoding: {
       type: 'pkcs1',
       format: 'pem'


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/209](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/209)

To fix the issue, the modulus length of the RSA key should be increased to at least 2048 bits, as recommended for secure RSA encryption. This change ensures that the generated key meets modern cryptographic standards while maintaining the functionality of the test. The fix involves modifying the `modulusLength` parameter in the `generateKeyPairSync` function call.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
