### PR TITLE
Potential fix for code scanning alert no. 212: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-keygen-rfc8017-a-2-3.js
+++ b/test/parallel/test-crypto-keygen-rfc8017-a-2-3.js
@@ -13,11 +13,11 @@ const {
 // saltLength is the octet length of the hash value."
 {
   generateKeyPair('rsa-pss', {
-    modulusLength: 512,
+    modulusLength: 2048,
     hashAlgorithm: 'sha512'
   }, common.mustSucceed((publicKey, privateKey) => {
     const expectedKeyDetails = {
-      modulusLength: 512,
+      modulusLength: 2048,
       publicExponent: 65537n,
       hashAlgorithm: 'sha512',
       mgf1HashAlgorithm: 'sha512',
@@ -29,12 +29,12 @@ const {
 
   // It is still possible to explicitly set saltLength to 0.
   generateKeyPair('rsa-pss', {
-    modulusLength: 512,
+    modulusLength: 2048,
     hashAlgorithm: 'sha512',
     saltLength: 0
   }, common.mustSucceed((publicKey, privateKey) => {
     const expectedKeyDetails = {
-      modulusLength: 512,
+      modulusLength: 2048,
       publicExponent: 65537n,
       hashAlgorithm: 'sha512',
       mgf1HashAlgorithm: 'sha512',


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/212](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/212)

To fix the issue, the `modulusLength` parameter in the `generateKeyPair` function calls should be updated from `512` to `2048`. This ensures that the RSA keys generated during the test meet the minimum recommended security standards. The test assertions should also be updated to reflect the new key size. No additional imports or dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
