### PR TITLE
Potential fix for code scanning alert no. 203: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-keygen-key-objects.js
+++ b/test/parallel/test-crypto-keygen-key-objects.js
@@ -12,7 +12,7 @@ const {
 // Test sync key generation with key objects.
 {
   const { publicKey, privateKey } = generateKeyPairSync('rsa', {
-    modulusLength: 512
+    modulusLength: 2048
   });
 
   assert.strictEqual(typeof publicKey, 'object');


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/203](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/203)

To fix the issue, the `modulusLength` parameter in the `generateKeyPairSync` function should be updated to use a secure key size of at least 2048 bits. This change ensures compliance with modern cryptographic standards while maintaining the functionality of the test. The rest of the test code can remain unchanged, as it is validating the structure and properties of the generated keys.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
