### PR TITLE
Potential fix for code scanning alert no. 215: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -634,7 +634,7 @@ const { inspect } = require('util');
   // too long salt length
   assert.throws(() => {
     generateKeyPair('rsa-pss', {
-      modulusLength: 512,
+      modulusLength: 2048,
       saltLength: 2147483648,
       hashAlgorithm: 'sha256',
       mgf1HashAlgorithm: 'sha256'
@@ -649,7 +649,7 @@ const { inspect } = require('util');
 
   assert.throws(() => {
     generateKeyPair('rsa-pss', {
-      modulusLength: 512,
+      modulusLength: 2048,
       saltLength: -1,
       hashAlgorithm: 'sha256',
       mgf1HashAlgorithm: 'sha256'


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/215](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/215)

To fix the issue, the `modulusLength` parameter should be updated to use a secure key size of at least 2048 bits. This ensures compliance with modern cryptographic standards and avoids the use of weak keys. The change should be applied to all instances where `modulusLength: 512` is used. If the test is specifically designed to validate the rejection of weak keys, it should be clearly documented, and the weak key size should be retained only if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
