### PR TITLE
Potential fix for code scanning alert no. 262: Useless regular-expression character escape

### DIFF
--- a/deps/v8/test/mjsunit/es6/unicode-escapes-in-regexps.js
+++ b/deps/v8/test/mjsunit/es6/unicode-escapes-in-regexps.js
@@ -262,7 +262,7 @@ assertEquals(["\u{10000}\u{10000}"],
              new RegExp("\\ud800\\udc00+", "u").exec("\u{10000}\u{10000}"));
 
 assertEquals(["\u{10003}\u{50001}"],
-             new RegExp("[\\ud800\\udc03-\\ud900\\udc01\]+", "u").exec(
+             new RegExp("[\\ud800\\udc03-\\ud900\\udc01]+", "u").exec(
                  "\u{10003}\u{50001}"));
 assertEquals(["\u{10003}\u{50001}"],
              new RegExp("[\ud800\udc03-\u{50001}\]+", "u").exec(


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/262](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/262)

To fix the issue, the unnecessary escape sequence `\]` should be replaced with `]`. This change will not alter the behavior of the regular expression but will improve its clarity and adherence to best practices. The fix should be applied to line 265, where the escape sequence is used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
