### PR TITLE
Potential fix for code scanning alert no. 205: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-keygen-key-object-without-encoding.js
+++ b/test/parallel/test-crypto-keygen-key-object-without-encoding.js
@@ -17,7 +17,7 @@ const {
 {
   // If no publicKeyEncoding is specified, a key object should be returned.
   generateKeyPair('rsa', {
-    modulusLength: 1024,
+    modulusLength: 2048,
     privateKeyEncoding: {
       type: 'pkcs1',
       format: 'pem'
@@ -36,7 +36,7 @@ const {
 
   // If no privateKeyEncoding is specified, a key object should be returned.
   generateKeyPair('rsa', {
-    modulusLength: 1024,
+    modulusLength: 2048,
     publicKeyEncoding: {
       type: 'pkcs1',
       format: 'pem'


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/205](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/205)

To fix the issue, the modulus length for RSA key generation should be increased to at least 2048 bits. This ensures compliance with modern cryptographic standards and avoids the use of weak keys. The changes should be applied to both instances of `generateKeyPair` in the code, specifically on lines 20 and 39. No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
