### PR TITLE
Potential fix for code scanning alert no. 199: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-keygen-duplicate-deprecated-option.js
+++ b/test/parallel/test-crypto-keygen-duplicate-deprecated-option.js
@@ -13,7 +13,7 @@ const {
 // simultaneously so long as they're identical values.
 {
   generateKeyPair('rsa-pss', {
-    modulusLength: 512,
+    modulusLength: 2048,
     saltLength: 16,
     hash: 'sha256',
     hashAlgorithm: 'sha256',


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/199](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/199)

To fix the issue, the `modulusLength` parameter in the `generateKeyPair` function should be updated to use a secure key size of at least 2048 bits, as recommended for RSA encryption. This change ensures that the test adheres to modern cryptographic standards while still validating the intended functionality. No other changes to the test logic are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
