### PR TITLE
Potential fix for code scanning alert no. 667: Multiplication result converted to larger type

### DIFF
--- a/deps/icu-small/source/common/propsvec.cpp
+++ b/deps/icu-small/source/common/propsvec.cpp
@@ -71,7 +71,7 @@ upvec_open(int32_t columns, UErrorCode *pErrorCode) {
 
     /* set the all-Unicode row and the special-value rows */
     row=pv->v;
-    uprv_memset(row, 0, pv->rows*columns*4);
+    uprv_memset(row, 0, static_cast<size_t>(pv->rows) * columns * 4);
     row[0]=0;
     row[1]=0x110000;
     row+=columns;


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/667](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/667)

To fix the issue, the multiplication should be performed using a larger integer type, such as `size_t`, to prevent overflow. This can be achieved by casting one of the operands to `size_t` before performing the multiplication. Specifically, casting `pv->rows` or `columns` to `size_t` ensures that the multiplication is done using `size_t` arithmetic, which can handle larger values.

The fix involves modifying the expression `pv->rows * columns * 4` on line 74 to cast one of the operands to `size_t`. No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
