### PR TITLE
Potential fix for code scanning alert no. 674: Multiplication result converted to larger type

### DIFF
--- a/deps/openssl/openssl/crypto/ec/curve448/curve448.c
+++ b/deps/openssl/openssl/crypto/ec/curve448/curve448.c
@@ -589,7 +589,7 @@ static int recode_wnaf(struct smvt_control *control,
             assert(pos < 32);       /* can't fail since current & 0xFFFF != 0 */
             if (odd & (1 << (table_bits + 1)))
                 delta -= (1 << (table_bits + 1));
-            current -= delta * (1 << pos);
+            current -= (uint64_t)delta * (1 << pos);
             control[position].power = pos + 16 * (w - 1);
             control[position].addend = delta;
             position--;


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/674](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/674)

To fix the issue, we need to ensure that the multiplication `delta * (1 << pos)` is performed in the larger type (`uint64_t`) to prevent overflow. This can be achieved by explicitly casting one of the operands (`delta` or `1 << pos`) to `uint64_t` before the multiplication. This ensures that the multiplication is performed in the larger type, avoiding any overflow in the intermediate result.

The specific change will be made on line 592, where the multiplication occurs. We will cast `delta` to `uint64_t` before performing the multiplication.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
