### PR TITLE
Potential fix for code scanning alert no. 677: Multiplication result converted to larger type

### DIFF
--- a/deps/zlib/zutil.c
+++ b/deps/zlib/zutil.c
@@ -285,7 +285,7 @@ extern void free(voidpf ptr);
 
 voidpf ZLIB_INTERNAL zcalloc(voidpf opaque, unsigned items, unsigned size) {
     (void)opaque;
-    return sizeof(uInt) > 2 ? (voidpf)malloc(items * size) :
+    return sizeof(uInt) > 2 ? (voidpf)malloc((size_t)items * size) :
                               (voidpf)calloc(items, size);
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/677](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/677)

To fix the issue, the multiplication should be performed using a larger type, such as `size_t`, to prevent overflow. This can be achieved by casting one of the operands (`items` or `size`) to `size_t` before performing the multiplication. This ensures that the multiplication is done using the larger type, avoiding overflow.

The specific change involves modifying line 288 to cast `items` or `size` to `size_t` before the multiplication. No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
