### PR TITLE
Potential fix for code scanning alert no. 664: Potentially overflowing call to snprintf

### DIFF
--- a/deps/uv/src/inet.c
+++ b/deps/uv/src/inet.c
@@ -130,7 +130,11 @@ static int inet_ntop6(const unsigned char *src, char *dst, size_t size) {
       tp += strlen(tp);
       break;
     }
-    tp += snprintf(tp, sizeof tmp - (tp - tmp), "%x", words[i]);
+    int n = snprintf(tp, sizeof tmp - (tp - tmp), "%x", words[i]);
+    if (n < 0 || n >= (int)(sizeof tmp - (tp - tmp))) {
+      return UV_ENOSPC;
+    }
+    tp += n;
   }
   /* Was it a trailing run of 0x00's? */
   if (best.base != -1 && (best.base + best.len) == ARRAY_SIZE(words))


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/664](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/664)

To fix the issue, the return value of `snprintf` should be checked to ensure it does not exceed the remaining buffer size. If the return value is negative or greater than or equal to the remaining size, the function should handle the error appropriately (e.g., by returning an error code). This ensures that the `tp` pointer does not advance beyond the bounds of the `tmp` buffer.

The fix involves:
1. Capturing the return value of `snprintf` in a variable.
2. Validating the return value to ensure it is within bounds.
3. Breaking out of the loop or returning an error code if the return value indicates an overflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
