### PR TITLE
Potential fix for code scanning alert no. 602: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/deps/icu-small/source/common/umapfile.cpp
+++ b/deps/icu-small/source/common/umapfile.cpp
@@ -211,16 +211,16 @@ typedef HANDLE MemoryMap;
         UDataMemory_init(pData); /* Clear the output struct.        */
 
         /* determine the length of the file */
-        if(stat(path, &mystat)!=0 || mystat.st_size<=0) {
-            return false;
-        }
-        length=mystat.st_size;
-
-        /* open the file */
         fd=open(path, O_RDONLY);
         if(fd==-1) {
             return false;
         }
+
+        if(fstat(fd, &mystat)!=0 || mystat.st_size<=0) {
+            close(fd);
+            return false;
+        }
+        length=mystat.st_size;
 
         /* get a view of the mapping */
 #if U_PLATFORM != U_PF_HPUX


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/602](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/602)

To fix the TOCTOU race condition, the `open` operation should be performed first, and the file descriptor obtained from `open` should be used for subsequent operations, such as `fstat` instead of `stat`. This ensures that the file being operated upon is the same file that was opened, as file descriptors are immutable and tied to the specific file.

**Steps to fix:**
1. Replace the `stat` call with `fstat` using the file descriptor obtained from `open`.
2. Ensure the file descriptor is closed after all operations are complete.
3. Modify the code to handle errors appropriately during the transition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
