### PR TITLE
Potential fix for code scanning alert no. 600: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/deps/icu-small/source/common/ucnvsel.cpp
+++ b/deps/icu-small/source/common/ucnvsel.cpp
@@ -722,7 +722,7 @@ static UEnumeration *selectForMask(const UConverterSelector* sel,
       return nullptr;
     }
     int32_t i, j;
-    int16_t k = 0;
+    int32_t k = 0;
     for (j = 0 ; j < columns; j++) {
       uint32_t v = mask[j];
       for (i = 0 ; i < 32 && k < sel->encodingsCount; i++, k++) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/600](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/600)

To fix the issue, the type of `k` should be changed from `int16_t` to `int32_t`. This ensures that `k` is at least as wide as `sel->encodingsCount`, preventing overflow and ensuring the comparison behaves correctly. The change should be made on line 725 where `k` is declared. No additional imports or definitions are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
