### PR TITLE
Potential fix for code scanning alert no. 849: Bad HTML filtering regexp

### DIFF
--- a/test/fixtures/snapshot/marked.js
+++ b/test/fixtures/snapshot/marked.js
@@ -1253,7 +1253,7 @@
   block$1.html = edit(block$1.html, 'i').replace('comment', block$1._comment).replace('tag', block$1._tag).replace('attribute', / +[a-zA-Z:_][\w.:-]*(?: *= *"[^"\n]*"| *= *'[^'\n]*'| *= *[^\s"'=<>`]+)?/).getRegex();
   block$1.paragraph = edit(block$1._paragraph).replace('hr', block$1.hr).replace('heading', ' {0,3}#{1,6} ').replace('|lheading', '') // setex headings don't interrupt commonmark paragraphs
   .replace('blockquote', ' {0,3}>').replace('fences', ' {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n').replace('list', ' {0,3}(?:[*+-]|1[.)]) ') // only lists starting from 1 can interrupt
-  .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|SCRIPT|pre|PRE|style|STYLE|textarea|TEXTAREA|!--)(?:\\s[^>]*)?>').replace('tag', block$1._tag) // pars can be interrupted by type (6) html blocks
+  .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|textarea|!--)(?:\\s[^>]*)?>').replace('tag', block$1._tag).getRegex('i') // pars can be interrupted by type (6) html blocks
   .getRegex();
   block$1.blockquote = edit(block$1.blockquote).replace('paragraph', block$1.paragraph).getRegex();
   /**


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/849](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/849)

To fix the issue, we should ensure that the regular expression matches HTML tags in a case-insensitive manner. Instead of manually listing all case variations (e.g., `script|SCRIPT`), we can use the `i` flag for case-insensitivity. Additionally, we should replace the custom regex-based approach with a well-tested library like `DOMPurify` if sanitization is the goal. However, since this is a markdown parser, we will focus on improving the regex to handle case-insensitivity properly.

The specific change involves modifying the regex on line 1256 to include the `i` flag for case-insensitivity. This ensures that tags like `<sCrIpT>` are matched correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
