### PR TITLE
Potential fix for code scanning alert no. 274: Useless regular-expression character escape

### DIFF
--- a/deps/v8/test/webkit/fast/regex/parentheses.js
+++ b/deps/v8/test/webkit/fast/regex/parentheses.js
@@ -247,7 +247,7 @@ shouldBeNull("regexp50.exec('((a)b{28,}c|d)x')");
 shouldBe("regexp50.exec('abbbbbbbbbbbbbbbbbbbbbbbbbbbbcx')", "['abbbbbbbbbbbbbbbbbbbbbbbbbbbbcx', 'abbbbbbbbbbbbbbbbbbbbbbbbbbbbc', 'a']");
 shouldBe("regexp50.exec('dx')", "['dx', 'd', undefined]");
 
-var s = "((.\s{-}).{28,}\P{Yi}?{,30}\|.)\x9e{-,}\P{Any}";
+var s = "((.\\s{-}).{28,}\\P{Yi}?{,30}\\|.)\\x9e{-,}\\P{Any}";
 var regexp51 = new RegExp(s);
 shouldBeNull("regexp51.exec('abc')");
 shouldBe("regexp51.exec(s)", "[')\x9e{-,}P{Any}',')',undefined]");


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/274](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/274)

To fix the issue, the string literal on line 250 should be updated to use double backslashes (`\\`) for characters that need to be escaped in the regular expression. This ensures that the `RegExp` constructor interprets the escape sequences correctly. Specifically, `\s` should be replaced with `\\s` to match whitespace, and other escape sequences in the string should be reviewed and corrected as needed.

The fix involves:
1. Updating the string literal on line 250 to properly escape `\s` as `\\s`.
2. Ensuring that other escape sequences in the string are correctly escaped (e.g., `\P` should be `\\P`, `\x9e` should be `\\x9e`, etc.).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
