### PR TITLE
Potential fix for code scanning alert no. 307: Bad HTML filtering regexp

### DIFF
--- a/tools/doc/common.mjs
+++ b/tools/doc/common.mjs
@@ -15,7 +15,7 @@ export function arrify(value) {
 export function extractAndParseYAML(text) {
   text = text.trim()
              .replace(/^<!-- YAML/, '')
-             .replace(/-->$/, '');
+             .replace(/--(?:>|!>)$/, '');
 
   // js-yaml.load() throws on error.
   const meta = yaml.load(text);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/307](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/307)

To fix the issue, the regular expression on line 18 should be updated to account for alternative valid HTML comment endings, such as `--!>`. This can be achieved by modifying the regex to match both `-->` and `--!>` at the end of the string. Additionally, it is recommended to use a well-tested library for HTML parsing and sanitization whenever possible, but in this case, a simple regex adjustment suffices for the specific use case.

The updated regex will look like `/--(?:>|!>)$/`, which matches either `-->` or `--!>` at the end of the string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
