### PR TITLE
Potential fix for code scanning alert no. 310: Incomplete string escaping or encoding

### DIFF
--- a/test/parallel/test-process-config.js
+++ b/test/parallel/test-process-config.js
@@ -49,7 +49,7 @@ let config = fs.readFileSync(configPath, 'utf8');
 
 // Clean up comment at the first line.
 config = config.split('\n').slice(1).join('\n');
-config = config.replace(/"/g, '\\"');
+config = config.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 config = config.replace(/'/g, '"');
 config = JSON.parse(config, (key, value) => {
   if (value === 'true') return true;


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/310](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/310)

To fix the issue, we need to ensure that backslashes are escaped before escaping double quotes. This can be achieved by adding a `replace` call to escape backslashes (`\\`) before escaping double quotes (`"`). The fix ensures that all occurrences of backslashes are replaced with double backslashes, followed by escaping double quotes. This approach prevents any ambiguity in the resulting string.

The changes will be made to the `config.replace` line in the file `test/parallel/test-process-config.js`. No new dependencies are required, as the fix uses native JavaScript functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
