### PR TITLE
Potential fix for code scanning alert no. 312: Incomplete string escaping or encoding

### DIFF
--- a/test/parallel/test-repl-editor.js
+++ b/test/parallel/test-repl-editor.js
@@ -11,7 +11,7 @@ common.skipIfDumbTerminal();
 // \u001b[0J - Clear screen
 // \u001b[0K - Clear to line end
 const terminalCode = '\u001b[1G\u001b[0J> \u001b[3G';
-const terminalCodeRegex = new RegExp(terminalCode.replace(/\[/g, '\\['), 'g');
+const terminalCodeRegex = new RegExp(terminalCode.replace(/\\/g, '\\\\').replace(/\[/g, '\\['), 'g');
 
 function run({ input, output, event, checkTerminalCodes = true }) {
   const stream = new ArrayStream();


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/312](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/312)

To fix the issue, we need to ensure that backslashes in the `terminalCode` string are properly escaped before constructing the regular expression. This can be achieved by replacing each backslash (`\`) with a double backslash (`\\`) in addition to the existing replacement for `[`.

The best way to implement this is to chain another `replace` call to escape backslashes before escaping the `[` character. This ensures that all occurrences of backslashes are handled correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
