### PR TITLE
Potential fix for code scanning alert no. 263: Useless regular-expression character escape

### DIFF
--- a/deps/v8/test/mjsunit/es6/unicode-escapes-in-regexps.js
+++ b/deps/v8/test/mjsunit/es6/unicode-escapes-in-regexps.js
@@ -265,7 +265,7 @@ assertEquals(["\u{10003}\u{50001}"],
              new RegExp("[\\ud800\\udc03-\\ud900\\udc01]+", "u").exec(
                  "\u{10003}\u{50001}"));
 assertEquals(["\u{10003}\u{50001}"],
-             new RegExp("[\ud800\udc03-\u{50001}\]+", "u").exec(
+             new RegExp("[\ud800\udc03-\u{50001}]+", "u").exec(
                  "\u{10003}\u{50001}"));
 
 // Unicode escape sequences to represent a non-BMP character cannot have


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/263](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/263)

To fix the issue, the unnecessary escape sequence `\]` should be replaced with the literal character `]`. This change ensures that the regular expression is written in a clear and concise manner without altering its functionality. Specifically, the line:

```js
new RegExp("[\ud800\udc03-\u{50001}\]+", "u")
```

should be updated to:

```js
new RegExp("[\ud800\udc03-\u{50001}]+", "u")
```

This removes the superfluous backslash before the closing square bracket.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
