### PR TITLE
Potential fix for code scanning alert no. 234: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-worker-thread.js
+++ b/test/parallel/test-crypto-worker-thread.js
@@ -19,7 +19,7 @@ if (isMainThread) {
   (async () => {
     const secretKey = generateKeySync('aes', { length: 128 });
     const { publicKey, privateKey } = generateKeyPairSync('rsa', {
-      modulusLength: 1024
+      modulusLength: 2048
     });
     const cryptoKey = await subtle.generateKey(
       { name: 'AES-CBC', length: 128 }, false, ['encrypt']);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/234](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/234)

To fix the issue, the `modulusLength` parameter in the `generateKeyPairSync` function should be updated from 1024 to 2048. This change ensures that the RSA key meets the recommended security standard. The functionality of the test will remain unchanged, as the key length does not affect the purpose of the test, which is to verify that key objects can be passed to worker threads without causing crashes.

The fix involves modifying the `modulusLength` value in the `generateKeyPairSync` call on line 21. No additional imports or changes to other parts of the code are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
