### PR TITLE
Potential fix for code scanning alert no. 596: Client-side cross-site scripting

### DIFF
--- a/test/fixtures/wpt/performance-timeline/resources/include-frames-subframe.html
+++ b/test/fixtures/wpt/performance-timeline/resources/include-frames-subframe.html
@@ -32,8 +32,13 @@
           resolve();
         });
 
-        childFrame.src = (new URL(document.location)).searchParams.get('origin')
-          + '/performance-timeline/resources/child-frame.html';
+        const allowedOrigins = ['https://example.com', 'https://another-trusted-site.com'];
+        const origin = (new URL(document.location)).searchParams.get('origin');
+        if (allowedOrigins.includes(origin)) {
+          childFrame.src = origin + '/performance-timeline/resources/child-frame.html';
+        } else {
+          console.error('Invalid origin parameter:', origin);
+        }
 
         document.body.appendChild(childFrame);
       }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/596](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/596)

To fix the issue, the `origin` parameter should be validated and sanitized before being used. A robust approach is to ensure that the value of `origin` is a trusted URL. This can be achieved by:
1. Validating the `origin` parameter against a whitelist of allowed origins or using a regular expression to ensure it matches a safe pattern.
2. Encoding the value to prevent injection attacks.

In this case, we will validate the `origin` parameter against a whitelist of allowed origins. If the value is not in the whitelist, we will not set the iframe's `src` attribute.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
