### PR TITLE
Potential fix for code scanning alert no. 216: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-private-decrypt-gh32240.js
+++ b/test/parallel/test-crypto-private-decrypt-gh32240.js
@@ -14,7 +14,7 @@ const {
   privateDecrypt,
 } = require('crypto');
 
-const pair = generateKeyPairSync('rsa', { modulusLength: 512 });
+const pair = generateKeyPairSync('rsa', { modulusLength: 2048 });
 
 const expected = Buffer.from('shibboleth');
 const encrypted = publicEncrypt(pair.publicKey, expected);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/216](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/216)

To fix the issue, the RSA key generation should use a `modulusLength` of at least 2048 bits. This ensures compliance with modern cryptographic standards and avoids the use of a weak key. The change should be made on line 17, where the `generateKeyPairSync` function is called. No additional imports or changes to the rest of the code are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
