### PR TITLE
Potential fix for code scanning alert no. 217: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -748,7 +748,7 @@ const { inspect } = require('util');
   assert.throws(
     () => {
       generateKeyPair('rsa-pss', {
-        modulusLength: 512,
+        modulusLength: 2048,
         saltLength: 16,
         hashAlgorithm: 'sha256',
         mgf1HashAlgorithm: undefined


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/217](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/217)

To fix the issue, the modulus length for RSA key generation should be increased to at least 2048 bits, as recommended by cryptographic standards. This ensures that the test code adheres to best practices and avoids using insecure configurations, even for testing purposes. The change should be applied to all instances of RSA key generation where the modulus length is set to 512 bits.

Specifically:
- Update the `modulusLength` property in the `generateKeyPair` calls to use a value of 2048 or higher.
- Ensure that the test logic remains valid and continues to test the intended error conditions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
