### PR TITLE
Potential fix for code scanning alert no. 210: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-keygen-rsa-pss.js
+++ b/test/parallel/test-crypto-keygen-rsa-pss.js
@@ -17,7 +17,7 @@ const {
 // Test RSA-PSS.
 {
   generateKeyPair('rsa-pss', {
-    modulusLength: 512,
+    modulusLength: 2048,
     saltLength: 16,
     hashAlgorithm: 'sha256',
     mgf1HashAlgorithm: 'sha256'


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/210](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/210)

To fix the issue, the `modulusLength` parameter in the `generateKeyPair` function should be updated to use a secure key length of at least 2048 bits. This change ensures compliance with modern cryptographic standards and eliminates the use of a weak key. The fix involves modifying the `modulusLength` value in the test configuration from `512` to `2048`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
