### PR TITLE
Potential fix for code scanning alert no. 269: Useless regular-expression character escape

### DIFF
--- a/deps/v8/test/mjsunit/wasm/export-global.js
+++ b/deps/v8/test/mjsunit/wasm/export-global.js
@@ -36,7 +36,7 @@ d8.file.execute("test/mjsunit/wasm/wasm-module-builder.js");
   global.exportAs(export_name);
   global.exportAs(export_name);
   var error_msg =
-      'Duplicate export name \'(abc){10,20}ab?c?\.\.\.\' for global 0 and global 0';
+      'Duplicate export name \'(abc){10,20}ab?c?\\.\\.\\.\' for global 0 and global 0';
   assertThrows(
       () => builder.instantiate(), WebAssembly.CompileError,
       new RegExp(error_msg));


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/269](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/269)

To fix the issue, the escape sequence `\.` in the `error_msg` string should be replaced with `\\.`. This ensures that the period is properly escaped when the string is converted into a regular expression using `new RegExp(error_msg)`. In JavaScript string literals, a single backslash is used to escape characters, so `\\.` represents a literal backslash followed by a literal period. This change ensures that the period is treated as a literal character in the regular expression.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
