### PR TITLE
Potential fix for code scanning alert no. 240: Incomplete URL substring sanitization

### DIFF
--- a/deps/corepack/dist/lib/corepack.cjs
+++ b/deps/corepack/dist/lib/corepack.cjs
@@ -21842,11 +21842,15 @@ async function installVersion(installTarget, locator, { spec }) {
     }
   } else {
     url = decodeURIComponent(version3);
-    if (process.env.COREPACK_NPM_REGISTRY && url.startsWith(DEFAULT_NPM_REGISTRY_URL)) {
-      url = url.replace(
-        DEFAULT_NPM_REGISTRY_URL,
-        () => process.env.COREPACK_NPM_REGISTRY
-      );
+    if (process.env.COREPACK_NPM_REGISTRY) {
+      const parsedUrl = new URL(url);
+      const allowedHosts = ['registry.npmjs.org'];
+      if (allowedHosts.includes(parsedUrl.host)) {
+        url = url.replace(
+          DEFAULT_NPM_REGISTRY_URL,
+          () => process.env.COREPACK_NPM_REGISTRY
+        );
+      }
     }
   }
   log(`Installing ${locator.name}@${version3} from ${url}`);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/240](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/240)

To fix the issue, the code should parse the `url` using a URL-parsing library (e.g., Node.js's built-in `url` module or `URL` class) and validate the `host` property against a whitelist of allowed hosts. This ensures that the check is performed on the actual host of the URL, rather than relying on substring matching.

Steps to implement the fix:
1. Parse the `url` using the `URL` class to extract its `host`.
2. Compare the `host` against a whitelist of allowed hosts (e.g., `['registry.npmjs.org']`).
3. Replace the `url.startsWith(DEFAULT_NPM_REGISTRY_URL)` check with this new validation logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
