### PR TITLE
Potential fix for code scanning alert no. 202: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-keygen-invalid-parameter-encoding-dsa.js
+++ b/test/parallel/test-crypto-keygen-invalid-parameter-encoding-dsa.js
@@ -13,7 +13,7 @@ const {
 // Test invalid parameter encoding.
 {
   assert.throws(() => generateKeyPairSync('dsa', {
-    modulusLength: 1024,
+    modulusLength: 2048,
     publicKeyEncoding: {
       format: 'jwk'
     },


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/202](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/202)

To fix the issue, the `modulusLength` parameter should be updated to use a secure key size of at least 2048 bits. This ensures compliance with modern cryptographic standards while maintaining the functionality of the test. The change should be made directly in the test configuration object passed to `generateKeyPairSync`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
