### PR TITLE
Potential fix for code scanning alert no. 270: Useless regular-expression character escape

### DIFF
--- a/deps/v8/test/webkit/fast/regex/parentheses.js
+++ b/deps/v8/test/webkit/fast/regex/parentheses.js
@@ -160,7 +160,7 @@ shouldBeNull("regexp31.exec('Committer:')");
 var regexp32 = /\s*(m(\[[^\]]+\])|m(u?)("[^"]+"))\s*/;
 shouldBeNull("regexp32.exec('Committer:')");
 
-var regexp33 = RegExp('^(?:(?:(a)(xyz|[^>"\'\s]*)?)|(/?>)|.[^\w\s>]*)');
+var regexp33 = RegExp('^(?:(?:(a)(xyz|[^>"\'\\s]*)?)|(/?>)|.[^\\w\\s>]*)');
 shouldBe("regexp33.exec('> <head>')","['>',undefined,undefined,'>']");
 
 var regexp34 = /(?:^|\b)btn-\S+/;


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/270](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/270)

To fix the issue, the backslash in the string literal must be escaped with another backslash (`\\`) so that it is correctly interpreted as part of the regular expression. This ensures that `\s` is treated as the whitespace character class in the resulting regular expression.

The change will be made on line 163, where the `RegExp` constructor is used. The string literal will be updated to escape the backslash characters properly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
