### PR TITLE
Potential fix for code scanning alert no. 265: Useless regular-expression character escape

### DIFF
--- a/deps/v8/test/mjsunit/es6/unicode-escapes-in-regexps.js
+++ b/deps/v8/test/mjsunit/es6/unicode-escapes-in-regexps.js
@@ -270,8 +270,8 @@ assertEquals(["\u{10003}\u{50001}"],
 
 // Unicode escape sequences to represent a non-BMP character cannot have
 // mixed notation, and must follow the rules for RegExpUnicodeEscapeSequence.
-assertThrows(() => new RegExp("[\\ud800\udc03-\ud900\\udc01\]+", "u"));
-assertThrows(() => new RegExp("[\\ud800\udc03-\ud900\\udc01\]+", "u"));
+assertThrows(() => new RegExp("[\\ud800\udc03-\ud900\\udc01]+", "u"));
+assertThrows(() => new RegExp("[\\ud800\udc03-\ud900\\udc01]+", "u"));
 assertNull(new RegExp("\\ud800\udc00+", "u").exec("\u{10000}\u{10000}"));
 assertNull(new RegExp("\ud800\\udc00+", "u").exec("\u{10000}\u{10000}"));
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/265](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/265)

To fix the issue, the unnecessary escape sequence `\]` should be replaced with the literal character `]`. This change will not alter the behavior of the program but will make the code cleaner and more readable. Specifically, on line 274, the `\]` should be replaced with `]` in the regular expression string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
