### PR TITLE
Potential fix for code scanning alert no. 238: Use of a weak cryptographic key

### DIFF
--- a/benchmark/crypto/keygen.js
+++ b/benchmark/crypto/keygen.js
@@ -43,8 +43,8 @@ const methods = {
     bench.start();
     for (let i = 0; i < n; ++i) {
       generateKeyPairSync('dsa', {
-        modulusLength: 1024,
-        divisorLength: 160,
+        modulusLength: 2048,
+        divisorLength: 256,
       });
     }
     bench.end(n);
@@ -60,8 +60,8 @@ const methods = {
     bench.start();
     for (let i = 0; i < n; ++i)
       generateKeyPair('dsa', {
-        modulusLength: 1024,
-        divisorLength: 160,
+        modulusLength: 2048,
+        divisorLength: 256,
       }, done);
   },
 };


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/238](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/238)

To fix the issue, the modulus length for DSA key generation should be increased to at least 2048 bits, and the divisor length should be updated to a secure value, such as 256 bits. This ensures compliance with modern cryptographic standards and mitigates the risk of brute-force attacks. The changes should be applied to both the synchronous (`dsaSync`) and asynchronous (`dsaAsync`) methods in the file `benchmark/crypto/keygen.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
