### PR TITLE
Potential fix for code scanning alert no. 198: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-keygen-deprecation.js
+++ b/test/parallel/test-crypto-keygen-deprecation.js
@@ -21,7 +21,7 @@ const { generateKeyPair } = require('crypto');
   // This test makes sure deprecated options still work as intended
 
   generateKeyPair('rsa-pss', {
-    modulusLength: 512,
+    modulusLength: 2048,
     saltLength: 16,
     hash: 'sha256',
     mgf1Hash: 'sha256'


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/198](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/198)

To fix the issue, the `modulusLength` parameter in the `generateKeyPair` function should be updated from 512 to 2048. This ensures that the RSA key meets modern security standards while maintaining the functionality of the test. The change is localized to the test file and does not affect the overall behavior of the test, as the key size does not alter the deprecated options being tested.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
