### PR TITLE
Potential fix for code scanning alert no. 207: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-keygen-non-standard-public-exponent.js
+++ b/test/parallel/test-crypto-keygen-non-standard-public-exponent.js
@@ -14,14 +14,14 @@ const {
 {
   const { publicKey, privateKey } = generateKeyPairSync('rsa', {
     publicExponent: 3,
-    modulusLength: 512
+    modulusLength: 2048
   });
 
   assert.strictEqual(typeof publicKey, 'object');
   assert.strictEqual(publicKey.type, 'public');
   assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
   assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {
-    modulusLength: 512,
+    modulusLength: 2048,
     publicExponent: 3n
   });
 
@@ -29,7 +29,7 @@ const {
   assert.strictEqual(privateKey.type, 'private');
   assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
   assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {
-    modulusLength: 512,
+    modulusLength: 2048,
     publicExponent: 3n
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/207](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/207)

To fix the issue, the modulus length should be increased to at least 2048 bits, which is the recommended minimum for RSA encryption. This ensures that the generated key is cryptographically secure while still allowing the test to validate behavior with a non-standard public exponent. The public exponent can remain as `3` if the test specifically requires it, as long as the modulus length is updated.

The changes will involve modifying the `modulusLength` parameter in the `generateKeyPairSync` function call and updating the corresponding assertions to reflect the new modulus length.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
