### PR TITLE
Potential fix for code scanning alert no. 195: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-keygen-async-rsa.js
+++ b/test/parallel/test-crypto-keygen-async-rsa.js
@@ -19,7 +19,7 @@ const {
 {
   generateKeyPair('rsa', {
     publicExponent: 0x10001,
-    modulusLength: 512,
+    modulusLength: 2048,
     publicKeyEncoding: {
       type: 'pkcs1',
       format: 'der'


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/195](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/195)

To fix the issue, the modulus length of the RSA key should be increased to at least 2048 bits, as recommended by modern cryptographic standards. This change ensures that the generated key is secure and aligns with best practices. The fix involves modifying the `modulusLength` parameter in the `generateKeyPair` function call from `512` to `2048`. No additional imports or changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
