### PR TITLE
Potential fix for code scanning alert no. 193: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-keygen-async-encrypted-private-key-der.js
+++ b/test/parallel/test-crypto-keygen-async-encrypted-private-key-der.js
@@ -18,7 +18,7 @@ const {
 {
   generateKeyPair('rsa', {
     publicExponent: 0x10001,
-    modulusLength: 512,
+    modulusLength: 2048,
     publicKeyEncoding: {
       type: 'pkcs1',
       format: 'der'


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/193](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/193)

To fix the issue, the modulus length of the RSA key should be increased to at least 2048 bits, as recommended for secure RSA encryption. This change ensures that the generated key is cryptographically strong and adheres to modern security standards. The fix involves modifying the `modulusLength` property in the `generateKeyPair` function call.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
