### PR TITLE
Potential fix for code scanning alert no. 191: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-key-objects-messageport.js
+++ b/test/parallel/test-crypto-key-objects-messageport.js
@@ -45,7 +45,7 @@ process.env.HAS_STARTED_WORKER = 1;
   // The main thread generates keys and passes them to worker threads.
   const secretKey = generateKeySync('aes', { length: 128 });
   const { publicKey, privateKey } = generateKeyPairSync('rsa', {
-    modulusLength: 1024
+    modulusLength: 2048
   });
   const cryptoKey = await subtle.generateKey(
     { name: 'AES-CBC', length: 128 }, false, ['encrypt']);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/191](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/191)

To fix the issue, the RSA key generation on line 47 should be updated to use a modulus length of at least 2048 bits. This ensures the key meets modern security standards while maintaining the functionality of the test. The change involves modifying the `modulusLength` parameter in the `generateKeyPairSync` function call.

No additional imports or definitions are required, as the `crypto` module already supports generating RSA keys with a modulus length of 2048 bits.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
