### PR TITLE
Potential fix for code scanning alert no. 192: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-keygen-async-elliptic-curve-jwk-rsa.js
+++ b/test/parallel/test-crypto-keygen-async-elliptic-curve-jwk-rsa.js
@@ -12,7 +12,7 @@ const {
 // Test async elliptic curve key generation with 'jwk' encoding and RSA.
 {
   generateKeyPair('rsa', {
-    modulusLength: 1024,
+    modulusLength: 2048,
     publicKeyEncoding: {
       format: 'jwk'
     },


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/192](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/192)

To fix the issue, the `modulusLength` parameter in the `generateKeyPair` function should be updated to use a secure key length of at least 2048 bits. This change ensures compliance with modern cryptographic standards while maintaining the functionality of the test. No additional imports or changes to the structure of the code are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
