### PR TITLE
Potential fix for code scanning alert no. 194: Use of a weak cryptographic key

### DIFF
--- a/test/parallel/test-crypto-keygen-async-encrypted-private-key.js
+++ b/test/parallel/test-crypto-keygen-async-encrypted-private-key.js
@@ -18,7 +18,7 @@ const {
 {
   generateKeyPair('rsa', {
     publicExponent: 0x10001,
-    modulusLength: 512,
+    modulusLength: 2048,
     publicKeyEncoding: {
       type: 'pkcs1',
       format: 'der'


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/194](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/194)

To fix the issue, the modulus length of the RSA key should be increased from 512 bits to at least 2048 bits. This ensures that the generated key meets modern security standards. The change should be made directly in the `generateKeyPair` function call on line 21, where the `modulusLength` is specified. No other changes are required, as the rest of the code is unrelated to the key's strength.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
