### PR TITLE
Potential fix for code scanning alert no. 672: Multiplication result converted to larger type

### DIFF
--- a/deps/icu-small/source/tools/toolutil/toolutil.cpp
+++ b/deps/icu-small/source/tools/toolutil/toolutil.cpp
@@ -348,7 +348,7 @@ utm_open(const char *name, int32_t initialCapacity, int32_t maxCapacity, int32_t
         maxCapacity=initialCapacity;
     }
 
-    mem=(UToolMemory *)uprv_malloc(sizeof(UToolMemory)+initialCapacity*size);
+    mem=(UToolMemory *)uprv_malloc(sizeof(UToolMemory)+(unsigned long)initialCapacity*size);
     if(mem==nullptr) {
         fprintf(stderr, "error: %s - out of memory\n", name);
         exit(U_MEMORY_ALLOCATION_ERROR);


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/672](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/672)

To fix the issue, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be achieved by explicitly casting one of the operands (`initialCapacity` or `size`) to `unsigned long` before the multiplication. This ensures that the multiplication is carried out in the larger type, avoiding overflow.

The specific change will be made on line 351, where the multiplication occurs. We will cast `initialCapacity` to `unsigned long` before multiplying it with `size`. This change does not alter the functionality but ensures correctness by preventing overflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
