### PR TITLE
Potential fix for code scanning alert no. 665: Multiplication result converted to larger type

### DIFF
--- a/deps/icu-small/source/common/lstmbe.cpp
+++ b/deps/icu-small/source/common/lstmbe.cpp
@@ -327,7 +327,7 @@ public:
     }
 
     inline Array2D& clear() {
-        uprv_memset(data_, 0, d1_ * d2_ * sizeof(float));
+        uprv_memset(data_, 0, static_cast<size_t>(d1_) * d2_ * sizeof(float));
         return *this;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/665](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/665)

To fix the issue, we need to ensure that the multiplication `d1_ * d2_` is performed in a larger type, such as `size_t`, to prevent overflow. This can be achieved by explicitly casting one of the operands to `size_t` before the multiplication. The corrected code will ensure that the result of the multiplication is computed in the larger type, avoiding overflow, and then passed safely to `uprv_memset`.

The change will be made in the `clear` method of the `Array2D` class, specifically on line 330. No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
