### PR TITLE
Potential fix for code scanning alert no. 668: Multiplication result converted to larger type

### DIFF
--- a/deps/icu-small/source/common/utrie_swap.cpp
+++ b/deps/icu-small/source/common/utrie_swap.cpp
@@ -65,7 +65,7 @@ utrie_swap(const UDataSwapper *ds,
     }
 
     dataIs32 = (trie.options & UTRIE_OPTIONS_DATA_IS_32_BIT) != 0;
-    size=sizeof(UTrieHeader)+trie.indexLength*2+trie.dataLength*(dataIs32?4:2);
+    size=sizeof(UTrieHeader)+trie.indexLength*2+static_cast<int64_t>(trie.dataLength)*(dataIs32?4:2);
 
     if(length>=0) {
         UTrieHeader *outTrie;


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/668](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/668)

To fix the issue, the multiplication should be performed using a larger integer type, such as `int64_t`, to prevent overflow. This can be achieved by casting `trie.dataLength` to `int64_t` before the multiplication. This ensures that the multiplication is performed in the larger type, and the result is safely assigned to `size`.

The specific change involves modifying line 68 to cast `trie.dataLength` to `int64_t` before performing the multiplication. No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
