### PR TITLE
Potential fix for code scanning alert no. 670: Multiplication result converted to larger type

### DIFF
--- a/deps/icu-small/source/tools/toolutil/toolutil.cpp
+++ b/deps/icu-small/source/tools/toolutil/toolutil.cpp
@@ -406,12 +406,12 @@ utm_hasCapacity(UToolMemory *mem, int32_t capacity) {
         }
 
         if(mem->array==mem->staticArray) {
-            mem->array=uprv_malloc(newCapacity*mem->size);
+            mem->array=uprv_malloc(static_cast<size_t>(newCapacity) * mem->size);
             if(mem->array!=nullptr) {
                 uprv_memcpy(mem->array, mem->staticArray, (size_t)mem->idx*mem->size);
             }
         } else {
-            mem->array=uprv_realloc(mem->array, newCapacity*mem->size);
+            mem->array=uprv_realloc(mem->array, static_cast<size_t>(newCapacity) * mem->size);
         }
 
         if(mem->array==nullptr) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/670](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/670)

To fix the issue, the multiplication should be performed using a larger integer type (`size_t`) to ensure that no overflow occurs. This can be achieved by casting one or both operands to `size_t` before performing the multiplication. Specifically:
1. Cast `newCapacity` to `size_t` before multiplying it with `mem->size`.
2. This ensures that the multiplication is performed using `size_t`, which is typically a 64-bit type on modern platforms, preventing overflow.

The changes will be applied to the lines where memory allocation functions (`uprv_malloc` and `uprv_realloc`) are called.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
