### PR TITLE
Potential fix for code scanning alert no. 323: Prototype-polluting function

### DIFF
--- a/test/fixtures/wpt/resources/testharness.js
+++ b/test/fixtures/wpt/resources/testharness.js
@@ -4711,12 +4711,17 @@
         var components = name.split(".");
         var target = global_scope;
         for (var i = 0; i < components.length - 1; i++) {
+            if (components[i] === "__proto__" || components[i] === "constructor") {
+                continue; // Skip dangerous property names
+            }
             if (!(components[i] in target)) {
                 target[components[i]] = {};
             }
             target = target[components[i]];
         }
-        target[components[components.length - 1]] = object;
+        if (components[components.length - 1] !== "__proto__" && components[components.length - 1] !== "constructor") {
+            target[components[components.length - 1]] = object;
+        }
     }
 
     function is_same_origin(w) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/323](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/323)

To fix the issue, the `expose` function should validate the `components[i]` values before assigning them to the `target` object. Specifically, it should block the property names `__proto__` and `constructor` to prevent prototype pollution. This can be achieved by adding a conditional check to skip these property names during the assignment process.

The fix involves:
1. Adding a check to ensure `components[i]` is not `__proto__` or `constructor`.
2. Updating the loop in the `expose` function to include this validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
