### PR TITLE
Potential fix for code scanning alert no. 324: Prototype-polluting function

### DIFF
--- a/deps/v8/test/wasm-js/third_party/testharness.js
+++ b/deps/v8/test/wasm-js/third_party/testharness.js
@@ -3625,12 +3625,17 @@ policies and contribution forms [3].
         var components = name.split(".");
         var target = global_scope;
         for (var i = 0; i < components.length - 1; i++) {
+            if (components[i] === "__proto__" || components[i] === "constructor") {
+                continue; // Skip unsafe property names
+            }
             if (!(components[i] in target)) {
                 target[components[i]] = {};
             }
             target = target[components[i]];
         }
-        target[components[components.length - 1]] = object;
+        if (components[components.length - 1] !== "__proto__" && components[components.length - 1] !== "constructor") {
+            target[components[components.length - 1]] = object;
+        }
     }
 
     function is_same_origin(w) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/324](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/324)

To fix the issue, we need to guard against prototype pollution in the `expose` function. This can be achieved by blocking the assignment of special property names like `__proto__` and `constructor`. Additionally, we should ensure that the `components[i]` property is a valid key and does not lead to unsafe assignments.

The best approach is to add a check that skips any property names that could lead to prototype pollution. Specifically:
1. Add a condition to skip `__proto__` and `constructor` in the loop on line 3628.
2. Ensure that the assignment to `target` only occurs for safe property names.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
