### PR TITLE
Potential fix for code scanning alert no. 243: Overly permissive regular expression range

### DIFF
--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -191,7 +191,7 @@ test('assert.throws()', () => {
   );
 
   assert.throws(
-    () => assert.doesNotThrow(() => thrower(Error), /\[[a-z]{6}\s[A-z]{6}\]/g, 'user message'),
+    () => assert.doesNotThrow(() => thrower(Error), /\[[a-z]{6}\s[A-Z]{6}\]/g, 'user message'),
     {
       name: 'AssertionError',
       code: 'ERR_ASSERTION',


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/243](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/243)

To fix the problem, the overly permissive range `[A-z]` should be replaced with `[A-Z]`, which matches only uppercase letters. This ensures that the regular expression behaves as intended and avoids matching unintended characters. The change should be made directly in the regular expression on line 194.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
