### PR TITLE
Potential fix for code scanning alert no. 666: Multiplication result converted to larger type

### DIFF
--- a/deps/icu-small/source/common/propsvec.cpp
+++ b/deps/icu-small/source/common/propsvec.cpp
@@ -215,7 +215,7 @@ upvec_setValue(UPropsVectors *pv,
                 *pErrorCode=U_INTERNAL_PROGRAM_ERROR;
                 return;
             }
-            newVectors=(uint32_t *)uprv_malloc(newMaxRows*columns*4);
+            newVectors=(uint32_t *)uprv_malloc((size_t)newMaxRows*columns*4);
             if(newVectors==nullptr) {
                 *pErrorCode=U_MEMORY_ALLOCATION_ERROR;
                 return;


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/666](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/666)

To fix the issue, the multiplication should be performed using a larger integer type (e.g., `size_t`) to prevent overflow. This can be achieved by explicitly casting one of the operands to `size_t` before performing the multiplication. This ensures that the multiplication is done using the larger type, avoiding overflow.

The specific change involves modifying the expression `newMaxRows * columns * 4` on line 218 to cast `newMaxRows` or `columns` to `size_t` before the multiplication. This change does not alter the functionality but ensures safe arithmetic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
