### PR TITLE
Potential fix for code scanning alert no. 594: DOM text reinterpreted as HTML

### DIFF
--- a/deps/v8/tools/turbolizer/src/views/range-view.ts
+++ b/deps/v8/tools/turbolizer/src/views/range-view.ts
@@ -185,6 +185,16 @@ class Grid {
     return this.backgroundFocusRow >= bound[0] && this.backgroundFocusRow <= bound[1] &&
             this.backgroundFocusColumn >= bound[2] && this.backgroundFocusColumn <= bound[3];
   }
+  /**
+   * Escapes HTML special characters in a string to prevent XSS.
+   * @param str The string to escape.
+   * @returns The escaped string.
+   */
+  private escapeHtml(str: string): string {
+    const div = document.createElement('div');
+    div.innerText = str;
+    return div.innerHTML;
+  }
 }
 
 // This class is used as a wrapper to hide the switch between the
@@ -698,7 +708,7 @@ class StringConstructor {
       regEl.innerHTML = str;
     } else if (!isVirtual) {
       const span = "".padEnd(C.FIXED_REGISTER_LABEL_WIDTH - registerName.length, "_");
-      regEl.innerHTML = `HW - <span class='range-transparent'>${span}</span>${registerName}`;
+      regEl.innerHTML = `HW - <span class='range-transparent'>${span}</span>${this.escapeHtml(registerName)}`;
     } else {
       regEl.innerText = registerName;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/594](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/594)

To fix the issue, we need to ensure that any user-controlled input, such as `registerName`, is properly sanitized or escaped before being inserted into the DOM using `innerHTML`. The best approach is to use a library like `DOMPurify` to sanitize the input or to use `textContent` or `innerText` instead of `innerHTML` when possible. In this case, we can escape the `registerName` value to ensure that it is treated as plain text, even when interpolated into an HTML string.

The fix involves:
1. Escaping `registerName` before interpolating it into the HTML string on line 701.
2. Adding a utility function to perform HTML escaping if one does not already exist in the codebase.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
