### PR TITLE
Potential fix for code scanning alert no. 278: Shell command built from environment values

### DIFF
--- a/test/internet/test-corepack-yarn-install.js
+++ b/test/internet/test-corepack-yarn-install.js
@@ -44,7 +44,8 @@ const env = { ...process.env,
               NPM_CONFIG_TMP: path.join(npmSandbox, 'npm-tmp'),
               HOME: homeDir };
 
-exec(`${process.execPath} ${corepackYarnPath} install`, {
+const args = [corepackYarnPath, 'install'];
+require('child_process').execFile(process.execPath, args, {
   cwd: installDir,
   env: env,
 }, common.mustCall(handleExit));


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/278](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/278)

To fix the issue, the shell command should be constructed using `execFile` or `execFileSync` instead of `exec`. This allows the command and its arguments to be passed separately, avoiding interpretation by the shell. Specifically:
1. Replace the dynamic shell command string `` `${process.execPath} ${corepackYarnPath} install` `` with a direct call to `process.execPath` and pass `corepackYarnPath` and `install` as arguments.
2. Update the `exec` call to use `execFile` for safer execution.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
