### PR TITLE
Potential fix for code scanning alert no. 595: DOM text reinterpreted as HTML

### DIFF
--- a/test/fixtures/wpt/FileAPI/url/url_createobjecturl_file_img-manual.html
+++ b/test/fixtures/wpt/FileAPI/url/url_createobjecturl_file_img-manual.html
@@ -22,7 +22,12 @@
   var img = document.querySelector("#displayImage");
 
   fileInput.addEventListener("change", function(evt) {
-    img.src = window.URL.createObjectURL(fileInput.files[0]);
+    var file = fileInput.files[0];
+    if (file && file.type.startsWith("image/")) {
+      img.src = window.URL.createObjectURL(file);
+    } else {
+      alert("Please select a valid image file.");
+    }
   }, false);
 </script>
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/595](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/595)

To address the issue, we should validate the file type before creating a URL using `window.URL.createObjectURL`. This can be done by checking the `type` property of the file object to ensure it matches an expected image MIME type (e.g., `image/png`, `image/jpeg`, etc.). If the file type is invalid, we should not proceed with creating the URL or setting the `src` attribute of the `<img>` element.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
