### PR TITLE
Potential fix for code scanning alert no. 244: Overly permissive regular expression range

### DIFF
--- a/deps/npm/test/fixtures/clean-snapshot.js
+++ b/deps/npm/test/fixtures/clean-snapshot.js
@@ -7,7 +7,7 @@ const cleanNewlines = (s) => s.replace(/\r\n/g, '\n')
 // ideally this could be avoided but its easier to just
 // run this command inside cleanSnapshot
 const normalizePath = (str) => cleanNewlines(str)
-  .replace(/[A-z]:\\/g, '\\') // turn windows roots to posix ones
+  .replace(/[A-Za-z]:\\/g, '\\') // turn windows roots to posix ones
   .replace(/\\+/g, '/') // replace \ with /
 
 const pathRegex = (p) => new RegExp(normalizePath(p), 'gi')


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/244](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/244)

To fix the issue, the overly permissive range `A-z` should be replaced with a more precise range that matches only alphabetic characters. Specifically, the range `[A-Za-z]` should be used instead of `[A-z]`. This ensures that only uppercase and lowercase letters are matched, avoiding unintended matches of non-alphabetic characters.

The change should be made on line 10 of the file `deps/npm/test/fixtures/clean-snapshot.js`, where the regular expression is defined. No additional imports or definitions are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
