### PR TITLE
Potential fix for code scanning alert no. 882: DOM text reinterpreted as HTML

### DIFF
--- a/test/fixtures/wpt/FileAPI/url/url_createobjecturl_file_img-manual.html
+++ b/test/fixtures/wpt/FileAPI/url/url_createobjecturl_file_img-manual.html
@@ -24,7 +24,18 @@
   fileInput.addEventListener("change", function(evt) {
     var file = fileInput.files[0];
     if (file && file.type.startsWith("image/")) {
-      img.src = window.URL.createObjectURL(file);
+      var reader = new FileReader();
+      reader.onload = function(event) {
+        var image = new Image();
+        image.onload = function() {
+          img.src = window.URL.createObjectURL(file);
+        };
+        image.onerror = function() {
+          alert("The selected file is not a valid image.");
+        };
+        image.src = event.target.result;
+      };
+      reader.readAsDataURL(file);
     } else {
       alert("Please select a valid image file.");
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/882](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/882)

To address the issue, we will add an additional layer of validation to ensure the file is a valid image before creating a Blob URL. Specifically:
1. Use the `FileReader` API to read the file and verify that it is a valid image by attempting to load it into an `Image` object.
2. Only set the `img.src` attribute if the file is successfully validated as an image.

This approach ensures that even if an attacker manages to bypass the MIME type check, the file will not be used unless it is a valid image.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
