### PR TITLE
Potential fix for code scanning alert no. 593: DOM text reinterpreted as HTML

### DIFF
--- a/deps/v8/tools/turbolizer/src/views/range-view.ts
+++ b/deps/v8/tools/turbolizer/src/views/range-view.ts
@@ -705,7 +705,7 @@ class StringConstructor {
                                         : num[num.length - i];
         str = `${addition} ${str}`;
       }
-      regEl.innerHTML = str;
+      regEl.innerHTML = this.escapeHtml(str);
     } else if (!isVirtual) {
       const span = "".padEnd(C.FIXED_REGISTER_LABEL_WIDTH - registerName.length, "_");
       regEl.innerHTML = `HW - <span class='range-transparent'>${span}</span>${this.escapeHtml(registerName)}`;


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/593](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/593)

To fix the issue, we need to ensure that any data assigned to `innerHTML` is properly escaped to prevent XSS attacks. This can be achieved by introducing a utility function to escape HTML meta-characters (`<`, `>`, `&`, `"`, `'`) in the `str` variable before assigning it to `innerHTML`. The `escapeHtml` function already exists in the codebase, so we can use it to sanitize `str`.

Changes will be made to the `setRegisterString` method in the `StringConstructor` class. Specifically, the `str` variable will be sanitized using `this.escapeHtml()` before being assigned to `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
