### PR TITLE
Potential fix for code scanning alert no. 587: Improper code sanitization

### DIFF
--- a/test/embedding/test-embedding.js
+++ b/test/embedding/test-embedding.js
@@ -74,8 +74,27 @@ spawnSyncAndExit(
     signal: null,
   });
 
+function escapeUnsafeChars(str) {
+  const charMap = {
+    '<': '\\u003C',
+    '>': '\\u003E',
+    '/': '\\u002F',
+    '\\': '\\\\',
+    '\b': '\\b',
+    '\f': '\\f',
+    '\n': '\\n',
+    '\r': '\\r',
+    '\t': '\\t',
+    '\0': '\\0',
+    '\u2028': '\\u2028',
+    '\u2029': '\\u2029'
+  };
+  return str.replace(/[<>\b\f\n\r\t\0\u2028\u2029]/g, x => charMap[x]);
+}
+
 function getReadFileCodeForPath(path) {
-  return `(require("fs").readFileSync(${JSON.stringify(path)}, "utf8"))`;
+  const sanitizedPath = escapeUnsafeChars(JSON.stringify(path));
+  return `(require("fs").readFileSync(${sanitizedPath}, "utf8"))`;
 }
 
 // Basic snapshot support


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/587](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/587)

To fix the issue, we need to sanitize the `path` parameter in `getReadFileCodeForPath` to escape potentially dangerous characters before constructing the JavaScript code. This can be achieved by implementing a function similar to `escapeUnsafeChars` from the example provided in the background section. This function will replace unsafe characters with their escaped equivalents, ensuring that the dynamically constructed code is safe.

**Steps to fix:**
1. Define a helper function `escapeUnsafeChars` to sanitize strings by escaping unsafe characters.
2. Use this function to sanitize the `path` parameter before passing it to `JSON.stringify` in `getReadFileCodeForPath`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
