### PR TITLE
Potential fix for code scanning alert no. 888: Incomplete string escaping or encoding

### DIFF
--- a/test/embedding/test-embedding.js
+++ b/test/embedding/test-embedding.js
@@ -89,7 +89,7 @@ function escapeUnsafeChars(str) {
     '\u2028': '\\u2028',
     '\u2029': '\\u2029'
   };
-  return str.replace(/[<>\b\f\n\r\t\0\u2028\u2029]/g, x => charMap[x]);
+  return str.replace(/[<>\b\f\n\r\t\0\u2028\u2029\\]/g, x => charMap[x]);
 }
 
 function getReadFileCodeForPath(path) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/888](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/888)

To fix the issue, the regular expression in the `escapeUnsafeChars` function should be updated to include the backslash character (`\\`). This ensures that all occurrences of backslashes in the input string are properly escaped. The `charMap` already includes the correct mapping for backslashes, so no changes are needed there.

The updated regular expression will be `/[<>\b\f\n\r\t\0\u2028\u2029\\]/g`, which includes the backslash along with the other unsafe characters.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
