### PR TITLE
Potential fix for code scanning alert no. 893: DOM text reinterpreted as HTML

### DIFF
--- a/test/fixtures/wpt/FileAPI/url/url_createobjecturl_file_img-manual.html
+++ b/test/fixtures/wpt/FileAPI/url/url_createobjecturl_file_img-manual.html
@@ -32,8 +32,13 @@
             var objectURL = window.URL.createObjectURL(file);
             image.src = objectURL; // Use the Image object for validation
             image.onload = function() {
-              img.src = objectURL; // Assign to img.src only after validation
-              window.URL.revokeObjectURL(objectURL); // Revoke the object URL after successful assignment
+              if (image.width > 0 && image.height > 0) { // Ensure the image has valid dimensions
+                img.src = objectURL; // Assign to img.src only after validation
+                window.URL.revokeObjectURL(objectURL); // Revoke the object URL after successful assignment
+              } else {
+                alert("The selected file is not a valid image.");
+                window.URL.revokeObjectURL(objectURL); // Revoke the object URL to free resources
+              }
             };
             image.onerror = function() {
               alert("The selected file is not a valid image.");


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/893](https://github.com/Git-Hub-Chris/Nodejs/security/code-scanning/893)

To fix the issue, we need to ensure that the `objectURL` is safe before assigning it to the `img.src`. One approach is to use a sandboxed iframe or a secure method to validate the content of the file further. Alternatively, we can ensure that the `objectURL` is only used after thorough validation of the file content. In this case, the validation logic using the `Image` object can be enhanced to ensure that the file is indeed a valid image and does not contain malicious content.

The best fix involves:
1. Ensuring that the `objectURL` is assigned to the `img.src` only after the `Image` object successfully loads the file content.
2. Adding a fallback mechanism to handle cases where the file content is invalid or malicious.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
